### PR TITLE
New data for 3/29.

### DIFF
--- a/us-counties.csv
+++ b/us-counties.csv
@@ -12316,7 +12316,6 @@ date,county,state,fips,cases,deaths
 2020-03-25,Whitman,Washington,53075,2,0
 2020-03-25,Yakima,Washington,53077,51,1
 2020-03-25,Berkeley,West Virginia,54003,2,0
-2020-03-25,Hancock,West Virginia,54029,1,0
 2020-03-25,Harrison,West Virginia,54033,3,0
 2020-03-25,Jackson,West Virginia,54035,4,0
 2020-03-25,Jefferson,West Virginia,54037,3,0
@@ -16107,7 +16106,7 @@ date,county,state,fips,cases,deaths
 2020-03-28,Sumter,Florida,12119,40,0
 2020-03-28,Suwannee,Florida,12121,1,0
 2020-03-28,Unknown,Florida,,1,0
-2020-03-28,Volusia,Florida,12127,44,2
+2020-03-28,Volusia,Florida,12127,44,1
 2020-03-28,Walton,Florida,12131,15,0
 2020-03-28,Washington,Florida,12133,1,0
 2020-03-28,Baker,Georgia,13007,1,1
@@ -17444,7 +17443,7 @@ date,county,state,fips,cases,deaths
 2020-03-28,Guadalupe,Texas,48187,8,0
 2020-03-28,Hale,Texas,48189,1,0
 2020-03-28,Hardin,Texas,48199,6,1
-2020-03-28,Harris,Texas,48201,232,3
+2020-03-28,Harris,Texas,48201,445,3
 2020-03-28,Harrison,Texas,48203,1,0
 2020-03-28,Hays,Texas,48209,13,0
 2020-03-28,Hidalgo,Texas,48215,18,0
@@ -17730,3 +17729,1986 @@ date,county,state,fips,cases,deaths
 2020-03-28,Sweetwater,Wyoming,56037,1,0
 2020-03-28,Teton,Wyoming,56039,14,0
 2020-03-28,Washakie,Wyoming,56043,1,0
+2020-03-29,Autauga,Alabama,01001,6,0
+2020-03-29,Baldwin,Alabama,01003,15,0
+2020-03-29,Blount,Alabama,01009,5,0
+2020-03-29,Bullock,Alabama,01011,3,0
+2020-03-29,Butler,Alabama,01013,1,0
+2020-03-29,Calhoun,Alabama,01015,3,0
+2020-03-29,Chambers,Alabama,01017,27,1
+2020-03-29,Cherokee,Alabama,01019,2,0
+2020-03-29,Chilton,Alabama,01021,8,0
+2020-03-29,Choctaw,Alabama,01023,1,0
+2020-03-29,Clay,Alabama,01027,2,0
+2020-03-29,Cleburne,Alabama,01029,5,0
+2020-03-29,Colbert,Alabama,01033,2,0
+2020-03-29,Coosa,Alabama,01037,3,0
+2020-03-29,Covington,Alabama,01039,2,0
+2020-03-29,Crenshaw,Alabama,01041,1,0
+2020-03-29,Cullman,Alabama,01043,7,0
+2020-03-29,Dallas,Alabama,01047,2,0
+2020-03-29,DeKalb,Alabama,01049,4,0
+2020-03-29,Elmore,Alabama,01051,13,0
+2020-03-29,Escambia,Alabama,01053,1,0
+2020-03-29,Etowah,Alabama,01055,6,0
+2020-03-29,Franklin,Alabama,01059,3,0
+2020-03-29,Greene,Alabama,01063,3,0
+2020-03-29,Houston,Alabama,01069,8,0
+2020-03-29,Jackson,Alabama,01071,5,1
+2020-03-29,Jefferson,Alabama,01073,246,0
+2020-03-29,Lamar,Alabama,01075,1,0
+2020-03-29,Lauderdale,Alabama,01077,12,1
+2020-03-29,Lawrence,Alabama,01079,3,0
+2020-03-29,Lee,Alabama,01081,57,0
+2020-03-29,Limestone,Alabama,01083,16,0
+2020-03-29,Lowndes,Alabama,01085,1,0
+2020-03-29,Macon,Alabama,01087,1,0
+2020-03-29,Madison,Alabama,01089,80,1
+2020-03-29,Marengo,Alabama,01091,5,0
+2020-03-29,Marion,Alabama,01093,10,0
+2020-03-29,Marshall,Alabama,01095,5,0
+2020-03-29,Mobile,Alabama,01097,41,1
+2020-03-29,Monroe,Alabama,01099,1,0
+2020-03-29,Montgomery,Alabama,01101,22,0
+2020-03-29,Morgan,Alabama,01103,17,0
+2020-03-29,Pickens,Alabama,01107,2,0
+2020-03-29,Pike,Alabama,01109,4,0
+2020-03-29,Randolph,Alabama,01111,2,0
+2020-03-29,Russell,Alabama,01113,1,0
+2020-03-29,Shelby,Alabama,01117,79,0
+2020-03-29,St. Clair,Alabama,01115,13,0
+2020-03-29,Talladega,Alabama,01121,4,0
+2020-03-29,Tallapoosa,Alabama,01123,8,0
+2020-03-29,Tuscaloosa,Alabama,01125,23,0
+2020-03-29,Walker,Alabama,01127,30,0
+2020-03-29,Washington,Alabama,01129,4,0
+2020-03-29,Wilcox,Alabama,01131,2,0
+2020-03-29,Winston,Alabama,01133,2,0
+2020-03-29,Anchorage,Alaska,02020,59,2
+2020-03-29,Fairbanks North Star Borough,Alaska,02090,28,0
+2020-03-29,Juneau City and Borough,Alaska,02110,5,0
+2020-03-29,Kenai Peninsula Borough,Alaska,02122,7,0
+2020-03-29,Ketchikan Gateway Borough,Alaska,02130,13,0
+2020-03-29,Matanuska-Susitna Borough,Alaska,02170,2,0
+2020-03-29,Apache,Arizona,04001,13,0
+2020-03-29,Cochise,Arizona,04003,3,0
+2020-03-29,Coconino,Arizona,04005,68,2
+2020-03-29,Gila,Arizona,04007,1,0
+2020-03-29,Graham,Arizona,04009,2,0
+2020-03-29,La Paz,Arizona,04012,2,0
+2020-03-29,Maricopa,Arizona,04013,546,5
+2020-03-29,Mohave,Arizona,04015,6,0
+2020-03-29,Navajo,Arizona,04017,62,0
+2020-03-29,Pima,Arizona,04019,153,6
+2020-03-29,Pinal,Arizona,04021,51,0
+2020-03-29,Santa Cruz,Arizona,04023,2,0
+2020-03-29,Yavapai,Arizona,04025,12,0
+2020-03-29,Yuma,Arizona,04027,9,0
+2020-03-29,Arkansas,Arkansas,05001,1,0
+2020-03-29,Ashley,Arkansas,05003,1,0
+2020-03-29,Baxter,Arkansas,05005,1,0
+2020-03-29,Benton,Arkansas,05007,33,0
+2020-03-29,Boone,Arkansas,05009,1,0
+2020-03-29,Bradley,Arkansas,05011,4,0
+2020-03-29,Chicot,Arkansas,05017,2,0
+2020-03-29,Clark,Arkansas,05019,18,0
+2020-03-29,Cleburne,Arkansas,05023,56,2
+2020-03-29,Cleveland,Arkansas,05025,5,0
+2020-03-29,Columbia,Arkansas,05027,2,0
+2020-03-29,Conway,Arkansas,05029,2,1
+2020-03-29,Craighead,Arkansas,05031,6,0
+2020-03-29,Crawford,Arkansas,05033,2,0
+2020-03-29,Crittenden,Arkansas,05035,17,0
+2020-03-29,Cross,Arkansas,05037,2,0
+2020-03-29,Desha,Arkansas,05041,2,0
+2020-03-29,Drew,Arkansas,05043,2,0
+2020-03-29,Faulkner,Arkansas,05045,30,0
+2020-03-29,Garland,Arkansas,05051,26,0
+2020-03-29,Grant,Arkansas,05053,3,0
+2020-03-29,Greene,Arkansas,05055,3,0
+2020-03-29,Hempstead,Arkansas,05057,1,0
+2020-03-29,Hot Spring,Arkansas,05059,3,0
+2020-03-29,Howard,Arkansas,05061,3,0
+2020-03-29,Independence,Arkansas,05063,3,0
+2020-03-29,Jefferson,Arkansas,05069,26,0
+2020-03-29,Johnson,Arkansas,05071,1,0
+2020-03-29,Lawrence,Arkansas,05075,1,0
+2020-03-29,Lincoln,Arkansas,05079,6,0
+2020-03-29,Lonoke,Arkansas,05085,4,0
+2020-03-29,Nevada,Arkansas,05099,1,0
+2020-03-29,Perry,Arkansas,05105,1,0
+2020-03-29,Pike,Arkansas,05109,3,0
+2020-03-29,Poinsett,Arkansas,05111,3,0
+2020-03-29,Polk,Arkansas,05113,2,0
+2020-03-29,Pope,Arkansas,05115,4,0
+2020-03-29,Pulaski,Arkansas,05119,94,2
+2020-03-29,Randolph,Arkansas,05121,2,0
+2020-03-29,Saline,Arkansas,05125,6,0
+2020-03-29,Searcy,Arkansas,05129,4,0
+2020-03-29,Sebastian,Arkansas,05131,5,0
+2020-03-29,Sevier,Arkansas,05133,2,0
+2020-03-29,Stone,Arkansas,05137,4,0
+2020-03-29,Union,Arkansas,05139,6,0
+2020-03-29,Unknown,Arkansas,,61,3
+2020-03-29,Van Buren,Arkansas,05141,18,1
+2020-03-29,Washington,Arkansas,05143,15,0
+2020-03-29,White,Arkansas,05145,6,0
+2020-03-29,Woodruff,Arkansas,05147,1,0
+2020-03-29,Alameda,California,06001,291,6
+2020-03-29,Amador,California,06005,2,0
+2020-03-29,Butte,California,06007,5,0
+2020-03-29,Calaveras,California,06009,3,0
+2020-03-29,Colusa,California,06011,1,0
+2020-03-29,Contra Costa,California,06013,175,3
+2020-03-29,El Dorado,California,06017,12,0
+2020-03-29,Fresno,California,06019,43,0
+2020-03-29,Glenn,California,06021,1,0
+2020-03-29,Humboldt,California,06023,18,0
+2020-03-29,Imperial,California,06025,25,0
+2020-03-29,Inyo,California,06027,8,0
+2020-03-29,Kern,California,06029,51,1
+2020-03-29,Kings,California,06031,2,0
+2020-03-29,Los Angeles,California,06037,2136,37
+2020-03-29,Madera,California,06039,18,1
+2020-03-29,Marin,California,06041,93,1
+2020-03-29,Mendocino,California,06045,3,0
+2020-03-29,Merced,California,06047,8,0
+2020-03-29,Mono,California,06051,11,0
+2020-03-29,Monterey,California,06053,32,1
+2020-03-29,Napa,California,06055,11,0
+2020-03-29,Nevada,California,06057,12,0
+2020-03-29,Orange,California,06059,431,4
+2020-03-29,Placer,California,06061,53,2
+2020-03-29,Riverside,California,06065,195,8
+2020-03-29,Sacramento,California,06067,164,6
+2020-03-29,San Benito,California,06069,14,1
+2020-03-29,San Bernardino,California,06071,111,3
+2020-03-29,San Diego,California,06073,519,7
+2020-03-29,San Francisco,California,06075,343,5
+2020-03-29,San Joaquin,California,06077,121,5
+2020-03-29,San Luis Obispo,California,06079,71,0
+2020-03-29,San Mateo,California,06081,277,6
+2020-03-29,Santa Barbara,California,06083,68,0
+2020-03-29,Santa Clara,California,06085,646,26
+2020-03-29,Santa Cruz,California,06087,44,1
+2020-03-29,Shasta,California,06089,4,1
+2020-03-29,Siskiyou,California,06093,3,0
+2020-03-29,Solano,California,06095,39,0
+2020-03-29,Sonoma,California,06097,57,1
+2020-03-29,Stanislaus,California,06099,31,0
+2020-03-29,Sutter,California,06101,6,0
+2020-03-29,Tulare,California,06107,35,1
+2020-03-29,Tuolumne,California,06109,1,0
+2020-03-29,Unknown,California,,1,0
+2020-03-29,Ventura,California,06111,109,4
+2020-03-29,Yolo,California,06113,16,1
+2020-03-29,Yuba,California,06115,3,0
+2020-03-29,Adams,Colorado,08001,110,0
+2020-03-29,Alamosa,Colorado,08003,1,0
+2020-03-29,Arapahoe,Colorado,08005,241,3
+2020-03-29,Baca,Colorado,08009,1,0
+2020-03-29,Boulder,Colorado,08013,90,1
+2020-03-29,Broomfield,Colorado,08014,17,0
+2020-03-29,Chaffee,Colorado,08015,15,1
+2020-03-29,Clear Creek,Colorado,08019,3,0
+2020-03-29,Costilla,Colorado,08023,1,0
+2020-03-29,Crowley,Colorado,08025,1,1
+2020-03-29,Delta,Colorado,08029,1,0
+2020-03-29,Denver,Colorado,08031,408,5
+2020-03-29,Douglas,Colorado,08035,102,0
+2020-03-29,Eagle,Colorado,08037,187,2
+2020-03-29,El Paso,Colorado,08041,214,11
+2020-03-29,Elbert,Colorado,08039,3,0
+2020-03-29,Fremont,Colorado,08043,1,0
+2020-03-29,Garfield,Colorado,08045,25,0
+2020-03-29,Grand,Colorado,08049,2,0
+2020-03-29,Gunnison,Colorado,08051,79,1
+2020-03-29,Hinsdale,Colorado,08053,1,0
+2020-03-29,Huerfano,Colorado,08055,1,0
+2020-03-29,Jefferson,Colorado,08059,213,5
+2020-03-29,Kit Carson,Colorado,08063,1,0
+2020-03-29,La Plata,Colorado,08067,21,0
+2020-03-29,Larimer,Colorado,08069,84,3
+2020-03-29,Lincoln,Colorado,08073,1,0
+2020-03-29,Logan,Colorado,08075,5,0
+2020-03-29,Mesa,Colorado,08077,11,0
+2020-03-29,Mineral,Colorado,08079,1,0
+2020-03-29,Moffat,Colorado,08081,2,0
+2020-03-29,Montezuma,Colorado,08083,1,0
+2020-03-29,Montrose,Colorado,08085,8,0
+2020-03-29,Morgan,Colorado,08087,5,0
+2020-03-29,Otero,Colorado,08089,3,0
+2020-03-29,Park,Colorado,08093,3,0
+2020-03-29,Pitkin,Colorado,08097,27,2
+2020-03-29,Pueblo,Colorado,08101,18,1
+2020-03-29,Rio Grande,Colorado,08105,3,0
+2020-03-29,Routt,Colorado,08107,16,0
+2020-03-29,San Miguel,Colorado,08113,1,0
+2020-03-29,Summit,Colorado,08117,11,0
+2020-03-29,Teller,Colorado,08119,7,1
+2020-03-29,Unknown,Colorado,,186,0
+2020-03-29,Washington,Colorado,08121,1,0
+2020-03-29,Weld,Colorado,08123,180,9
+2020-03-29,Yuma,Colorado,08125,2,0
+2020-03-29,Fairfield,Connecticut,09001,1245,21
+2020-03-29,Hartford,Connecticut,09003,276,2
+2020-03-29,Litchfield,Connecticut,09005,87,0
+2020-03-29,Middlesex,Connecticut,09007,38,1
+2020-03-29,New Haven,Connecticut,09009,280,6
+2020-03-29,New London,Connecticut,09011,20,0
+2020-03-29,Tolland,Connecticut,09013,40,4
+2020-03-29,Windham,Connecticut,09015,7,0
+2020-03-29,Kent,Delaware,10001,25,2
+2020-03-29,New Castle,Delaware,10003,141,3
+2020-03-29,Sussex,Delaware,10005,66,1
+2020-03-29,District of Columbia,District of Columbia,11001,342,4
+2020-03-29,Alachua,Florida,12001,72,0
+2020-03-29,Baker,Florida,12003,8,0
+2020-03-29,Bay,Florida,12005,6,0
+2020-03-29,Bradford,Florida,12007,2,0
+2020-03-29,Brevard,Florida,12009,30,0
+2020-03-29,Broward,Florida,12011,1012,11
+2020-03-29,Charlotte,Florida,12015,16,0
+2020-03-29,Citrus,Florida,12017,16,1
+2020-03-29,Clay,Florida,12019,35,4
+2020-03-29,Collier,Florida,12021,111,1
+2020-03-29,Columbia,Florida,12023,3,0
+2020-03-29,DeSoto,Florida,12027,7,0
+2020-03-29,Duval,Florida,12031,142,3
+2020-03-29,Escambia,Florida,12033,37,0
+2020-03-29,Flagler,Florida,12035,13,0
+2020-03-29,Gadsden,Florida,12039,1,0
+2020-03-29,Glades,Florida,12043,1,0
+2020-03-29,Hendry,Florida,12051,2,0
+2020-03-29,Hernando,Florida,12053,20,0
+2020-03-29,Highlands,Florida,12055,12,1
+2020-03-29,Hillsborough,Florida,12057,225,2
+2020-03-29,Indian River,Florida,12061,20,0
+2020-03-29,Jackson,Florida,12063,2,0
+2020-03-29,Lake,Florida,12069,44,0
+2020-03-29,Lee,Florida,12071,151,6
+2020-03-29,Leon,Florida,12073,16,0
+2020-03-29,Levy,Florida,12075,2,0
+2020-03-29,Manatee,Florida,12081,38,1
+2020-03-29,Marion,Florida,12083,22,0
+2020-03-29,Martin,Florida,12085,27,0
+2020-03-29,Miami-Dade,Florida,12086,1471,3
+2020-03-29,Monroe,Florida,12087,23,0
+2020-03-29,Nassau,Florida,12089,8,0
+2020-03-29,Okaloosa,Florida,12091,31,0
+2020-03-29,Orange,Florida,12095,267,4
+2020-03-29,Osceola,Florida,12097,89,0
+2020-03-29,Palm Beach,Florida,12099,382,7
+2020-03-29,Pasco,Florida,12101,35,2
+2020-03-29,Pinellas,Florida,12103,116,5
+2020-03-29,Polk,Florida,12105,46,0
+2020-03-29,Putnam,Florida,12107,12,0
+2020-03-29,Santa Rosa,Florida,12113,21,2
+2020-03-29,Sarasota,Florida,12115,61,2
+2020-03-29,Seminole,Florida,12117,81,0
+2020-03-29,St. Johns,Florida,12109,59,2
+2020-03-29,St. Lucie,Florida,12111,24,2
+2020-03-29,Sumter,Florida,12119,45,0
+2020-03-29,Suwannee,Florida,12121,2,0
+2020-03-29,Unknown,Florida,,1,0
+2020-03-29,Volusia,Florida,12127,60,1
+2020-03-29,Wakulla,Florida,12129,1,0
+2020-03-29,Walton,Florida,12131,15,0
+2020-03-29,Washington,Florida,12133,1,0
+2020-03-29,Bacon,Georgia,13005,1,0
+2020-03-29,Baker,Georgia,13007,1,1
+2020-03-29,Baldwin,Georgia,13009,2,0
+2020-03-29,Barrow,Georgia,13013,6,1
+2020-03-29,Bartow,Georgia,13015,119,1
+2020-03-29,Ben Hill,Georgia,13017,2,0
+2020-03-29,Bibb,Georgia,13021,14,0
+2020-03-29,Brooks,Georgia,13027,1,0
+2020-03-29,Bryan,Georgia,13029,7,0
+2020-03-29,Bulloch,Georgia,13031,1,0
+2020-03-29,Burke,Georgia,13033,4,0
+2020-03-29,Butts,Georgia,13035,5,0
+2020-03-29,Calhoun,Georgia,13037,3,0
+2020-03-29,Camden,Georgia,13039,2,0
+2020-03-29,Candler,Georgia,13043,1,0
+2020-03-29,Carroll,Georgia,13045,70,0
+2020-03-29,Catoosa,Georgia,13047,3,0
+2020-03-29,Charlton,Georgia,13049,1,0
+2020-03-29,Chatham,Georgia,13051,16,0
+2020-03-29,Chattahoochee,Georgia,13053,1,0
+2020-03-29,Chattooga,Georgia,13055,1,0
+2020-03-29,Cherokee,Georgia,13057,60,1
+2020-03-29,Clarke,Georgia,13059,35,2
+2020-03-29,Clayton,Georgia,13063,59,1
+2020-03-29,Clinch,Georgia,13065,1,0
+2020-03-29,Cobb,Georgia,13067,228,9
+2020-03-29,Coffee,Georgia,13069,10,0
+2020-03-29,Colquitt,Georgia,13071,6,0
+2020-03-29,Columbia,Georgia,13073,12,0
+2020-03-29,Coweta,Georgia,13077,23,2
+2020-03-29,Crisp,Georgia,13081,6,0
+2020-03-29,Dawson,Georgia,13085,4,0
+2020-03-29,DeKalb,Georgia,13089,273,3
+2020-03-29,Decatur,Georgia,13087,4,0
+2020-03-29,Dodge,Georgia,13091,1,0
+2020-03-29,Dougherty,Georgia,13095,247,17
+2020-03-29,Douglas,Georgia,13097,38,1
+2020-03-29,Early,Georgia,13099,16,1
+2020-03-29,Effingham,Georgia,13103,4,0
+2020-03-29,Fannin,Georgia,13111,3,0
+2020-03-29,Fayette,Georgia,13113,27,3
+2020-03-29,Floyd,Georgia,13115,28,2
+2020-03-29,Forsyth,Georgia,13117,28,1
+2020-03-29,Franklin,Georgia,13119,2,0
+2020-03-29,Fulton,Georgia,13121,425,12
+2020-03-29,Glynn,Georgia,13127,8,0
+2020-03-29,Gordon,Georgia,13129,14,1
+2020-03-29,Greene,Georgia,13133,1,0
+2020-03-29,Gwinnett,Georgia,13135,145,1
+2020-03-29,Habersham,Georgia,13137,1,0
+2020-03-29,Hall,Georgia,13139,33,0
+2020-03-29,Haralson,Georgia,13143,2,0
+2020-03-29,Harris,Georgia,13145,3,0
+2020-03-29,Hart,Georgia,13147,1,0
+2020-03-29,Heard,Georgia,13149,1,1
+2020-03-29,Henry,Georgia,13151,56,2
+2020-03-29,Houston,Georgia,13153,15,1
+2020-03-29,Irwin,Georgia,13155,3,0
+2020-03-29,Jackson,Georgia,13157,2,0
+2020-03-29,Jasper,Georgia,13159,2,0
+2020-03-29,Jenkins,Georgia,13165,1,0
+2020-03-29,Jones,Georgia,13169,2,0
+2020-03-29,Lamar,Georgia,13171,3,0
+2020-03-29,Laurens,Georgia,13175,12,0
+2020-03-29,Lee,Georgia,13177,43,6
+2020-03-29,Liberty,Georgia,13179,3,0
+2020-03-29,Lincoln,Georgia,13181,3,0
+2020-03-29,Long,Georgia,13183,1,0
+2020-03-29,Lowndes,Georgia,13185,20,1
+2020-03-29,Lumpkin,Georgia,13187,4,0
+2020-03-29,Macon,Georgia,13193,1,0
+2020-03-29,Madison,Georgia,13195,3,0
+2020-03-29,McDuffie,Georgia,13189,1,0
+2020-03-29,Meriwether,Georgia,13199,5,0
+2020-03-29,Miller,Georgia,13201,4,0
+2020-03-29,Mitchell,Georgia,13205,15,0
+2020-03-29,Monroe,Georgia,13207,3,0
+2020-03-29,Morgan,Georgia,13211,1,0
+2020-03-29,Murray,Georgia,13213,3,0
+2020-03-29,Muscogee,Georgia,13215,9,0
+2020-03-29,Newton,Georgia,13217,18,0
+2020-03-29,Oconee,Georgia,13219,11,0
+2020-03-29,Paulding,Georgia,13223,23,0
+2020-03-29,Peach,Georgia,13225,6,1
+2020-03-29,Pickens,Georgia,13227,5,1
+2020-03-29,Pierce,Georgia,13229,2,0
+2020-03-29,Pike,Georgia,13231,2,0
+2020-03-29,Polk,Georgia,13233,10,0
+2020-03-29,Pulaski,Georgia,13235,3,0
+2020-03-29,Randolph,Georgia,13243,3,0
+2020-03-29,Richmond,Georgia,13245,12,0
+2020-03-29,Rockdale,Georgia,13247,18,1
+2020-03-29,Seminole,Georgia,13253,5,0
+2020-03-29,Spalding,Georgia,13255,12,0
+2020-03-29,Stephens,Georgia,13257,3,0
+2020-03-29,Sumter,Georgia,13261,15,1
+2020-03-29,Tattnall,Georgia,13267,2,0
+2020-03-29,Taylor,Georgia,13269,1,0
+2020-03-29,Terrell,Georgia,13273,10,2
+2020-03-29,Thomas,Georgia,13275,7,0
+2020-03-29,Tift,Georgia,13277,13,0
+2020-03-29,Toombs,Georgia,13279,2,0
+2020-03-29,Troup,Georgia,13285,10,1
+2020-03-29,Turner,Georgia,13287,2,0
+2020-03-29,Twiggs,Georgia,13289,2,0
+2020-03-29,Unknown,Georgia,,228,2
+2020-03-29,Upson,Georgia,13293,5,0
+2020-03-29,Walton,Georgia,13297,4,0
+2020-03-29,Ware,Georgia,13299,5,0
+2020-03-29,Washington,Georgia,13303,2,0
+2020-03-29,Wheeler,Georgia,13309,1,0
+2020-03-29,White,Georgia,13311,1,0
+2020-03-29,Whitfield,Georgia,13313,8,2
+2020-03-29,Wilkes,Georgia,13317,1,0
+2020-03-29,Worth,Georgia,13321,10,1
+2020-03-29,Unknown,Guam,,58,1
+2020-03-29,Hawaii,Hawaii,15001,12,0
+2020-03-29,Honolulu,Hawaii,15003,119,0
+2020-03-29,Kauai,Hawaii,15007,12,0
+2020-03-29,Maui,Hawaii,15009,20,0
+2020-03-29,Unknown,Hawaii,,10,0
+2020-03-29,Ada,Idaho,16001,113,2
+2020-03-29,Bannock,Idaho,16005,3,0
+2020-03-29,Bingham,Idaho,16011,1,0
+2020-03-29,Blaine,Idaho,16013,115,2
+2020-03-29,Bonneville,Idaho,16019,1,0
+2020-03-29,Canyon,Idaho,16027,40,1
+2020-03-29,Cassia,Idaho,16031,1,0
+2020-03-29,Custer,Idaho,16037,1,0
+2020-03-29,Fremont,Idaho,16043,1,0
+2020-03-29,Gem,Idaho,16045,3,0
+2020-03-29,Idaho,Idaho,16049,1,0
+2020-03-29,Jefferson,Idaho,16051,2,0
+2020-03-29,Kootenai,Idaho,16055,13,0
+2020-03-29,Lincoln,Idaho,16063,1,0
+2020-03-29,Madison,Idaho,16065,2,0
+2020-03-29,Nez Perce,Idaho,16069,4,1
+2020-03-29,Owyhee,Idaho,16073,1,0
+2020-03-29,Payette,Idaho,16075,1,0
+2020-03-29,Teton,Idaho,16081,2,0
+2020-03-29,Twin Falls,Idaho,16083,3,0
+2020-03-29,Valley,Idaho,16085,1,0
+2020-03-29,Adams,Illinois,17001,2,0
+2020-03-29,Bond,Illinois,17005,1,0
+2020-03-29,Bureau,Illinois,17011,1,0
+2020-03-29,Carroll,Illinois,17015,1,0
+2020-03-29,Champaign,Illinois,17019,21,0
+2020-03-29,Christian,Illinois,17021,19,0
+2020-03-29,Clinton,Illinois,17027,6,0
+2020-03-29,Cook,Illinois,17031,3445,40
+2020-03-29,Cumberland,Illinois,17035,1,0
+2020-03-29,DeKalb,Illinois,17037,8,0
+2020-03-29,Douglas,Illinois,17041,1,0
+2020-03-29,DuPage,Illinois,17043,274,7
+2020-03-29,Fayette,Illinois,17051,1,0
+2020-03-29,Franklin,Illinois,17055,2,0
+2020-03-29,Grundy,Illinois,17063,3,0
+2020-03-29,Henry,Illinois,17073,2,0
+2020-03-29,Iroquois,Illinois,17075,2,0
+2020-03-29,Jackson,Illinois,17077,3,0
+2020-03-29,Jo Daviess,Illinois,17085,1,0
+2020-03-29,Kane,Illinois,17089,100,7
+2020-03-29,Kankakee,Illinois,17091,38,0
+2020-03-29,Kendall,Illinois,17093,15,1
+2020-03-29,Knox,Illinois,17095,1,0
+2020-03-29,LaSalle,Illinois,17099,4,2
+2020-03-29,Lake,Illinois,17097,300,3
+2020-03-29,Livingston,Illinois,17105,2,0
+2020-03-29,Macon,Illinois,17115,2,0
+2020-03-29,Madison,Illinois,17119,12,0
+2020-03-29,Marshall,Illinois,17123,1,0
+2020-03-29,McHenry,Illinois,17111,52,2
+2020-03-29,McLean,Illinois,17113,14,1
+2020-03-29,Menard,Illinois,17129,1,0
+2020-03-29,Monroe,Illinois,17133,3,0
+2020-03-29,Montgomery,Illinois,17135,1,0
+2020-03-29,Morgan,Illinois,17137,3,0
+2020-03-29,Peoria,Illinois,17143,8,0
+2020-03-29,Rock Island,Illinois,17161,5,0
+2020-03-29,Sangamon,Illinois,17167,9,1
+2020-03-29,St. Clair,Illinois,17163,31,3
+2020-03-29,Stephenson,Illinois,17177,3,0
+2020-03-29,Tazewell,Illinois,17179,4,0
+2020-03-29,Unknown,Illinois,,58,0
+2020-03-29,Washington,Illinois,17189,1,0
+2020-03-29,Whiteside,Illinois,17195,3,0
+2020-03-29,Will,Illinois,17197,192,4
+2020-03-29,Williamson,Illinois,17199,1,0
+2020-03-29,Winnebago,Illinois,17201,12,0
+2020-03-29,Woodford,Illinois,17203,3,0
+2020-03-29,Adams,Indiana,18001,1,0
+2020-03-29,Allen,Indiana,18003,26,1
+2020-03-29,Bartholomew,Indiana,18005,10,0
+2020-03-29,Boone,Indiana,18011,13,0
+2020-03-29,Brown,Indiana,18013,3,0
+2020-03-29,Carroll,Indiana,18015,1,0
+2020-03-29,Clark,Indiana,18019,20,0
+2020-03-29,Clay,Indiana,18021,1,0
+2020-03-29,Clinton,Indiana,18023,1,0
+2020-03-29,Crawford,Indiana,18025,1,0
+2020-03-29,DeKalb,Indiana,18033,1,0
+2020-03-29,Dearborn,Indiana,18029,10,1
+2020-03-29,Decatur,Indiana,18031,40,0
+2020-03-29,Delaware,Indiana,18035,14,1
+2020-03-29,Dubois,Indiana,18037,2,0
+2020-03-29,Elkhart,Indiana,18039,12,0
+2020-03-29,Fayette,Indiana,18041,5,1
+2020-03-29,Floyd,Indiana,18043,14,0
+2020-03-29,Fountain,Indiana,18045,1,0
+2020-03-29,Franklin,Indiana,18047,26,3
+2020-03-29,Fulton,Indiana,18049,1,0
+2020-03-29,Gibson,Indiana,18051,4,0
+2020-03-29,Grant,Indiana,18053,7,0
+2020-03-29,Greene,Indiana,18055,1,0
+2020-03-29,Hamilton,Indiana,18057,83,0
+2020-03-29,Hancock,Indiana,18059,22,1
+2020-03-29,Harrison,Indiana,18061,14,0
+2020-03-29,Hendricks,Indiana,18063,48,1
+2020-03-29,Henry,Indiana,18065,2,0
+2020-03-29,Howard,Indiana,18067,12,1
+2020-03-29,Huntington,Indiana,18069,1,0
+2020-03-29,Jackson,Indiana,18071,7,0
+2020-03-29,Jasper,Indiana,18073,6,1
+2020-03-29,Jennings,Indiana,18079,13,0
+2020-03-29,Johnson,Indiana,18081,71,3
+2020-03-29,Knox,Indiana,18083,2,0
+2020-03-29,Kosciusko,Indiana,18085,3,0
+2020-03-29,LaGrange,Indiana,18087,2,0
+2020-03-29,LaPorte,Indiana,18091,6,0
+2020-03-29,Lake,Indiana,18089,85,1
+2020-03-29,Lawrence,Indiana,18093,8,0
+2020-03-29,Madison,Indiana,18095,18,1
+2020-03-29,Marion,Indiana,18097,676,10
+2020-03-29,Marshall,Indiana,18099,3,0
+2020-03-29,Miami,Indiana,18103,1,0
+2020-03-29,Monroe,Indiana,18105,22,0
+2020-03-29,Montgomery,Indiana,18107,5,0
+2020-03-29,Morgan,Indiana,18109,20,1
+2020-03-29,Newton,Indiana,18111,1,0
+2020-03-29,Noble,Indiana,18113,2,0
+2020-03-29,Ohio,Indiana,18115,1,0
+2020-03-29,Orange,Indiana,18117,1,0
+2020-03-29,Owen,Indiana,18119,9,0
+2020-03-29,Porter,Indiana,18127,14,0
+2020-03-29,Posey,Indiana,18129,3,0
+2020-03-29,Putnam,Indiana,18133,5,1
+2020-03-29,Randolph,Indiana,18135,1,0
+2020-03-29,Ripley,Indiana,18137,19,0
+2020-03-29,Rush,Indiana,18139,2,0
+2020-03-29,Scott,Indiana,18143,1,1
+2020-03-29,Shelby,Indiana,18145,12,0
+2020-03-29,St. Joseph,Indiana,18141,32,1
+2020-03-29,Starke,Indiana,18149,1,0
+2020-03-29,Steuben,Indiana,18151,1,0
+2020-03-29,Sullivan,Indiana,18153,1,0
+2020-03-29,Switzerland,Indiana,18155,3,0
+2020-03-29,Tippecanoe,Indiana,18157,11,1
+2020-03-29,Tipton,Indiana,18159,4,0
+2020-03-29,Vanderburgh,Indiana,18163,17,0
+2020-03-29,Vermillion,Indiana,18165,1,0
+2020-03-29,Vigo,Indiana,18167,7,1
+2020-03-29,Wabash,Indiana,18169,1,0
+2020-03-29,Warren,Indiana,18171,2,0
+2020-03-29,Warrick,Indiana,18173,8,0
+2020-03-29,Washington,Indiana,18175,5,0
+2020-03-29,Wayne,Indiana,18177,1,0
+2020-03-29,Wells,Indiana,18179,1,0
+2020-03-29,White,Indiana,18181,1,0
+2020-03-29,Whitley,Indiana,18183,1,0
+2020-03-29,Adair,Iowa,19001,1,0
+2020-03-29,Allamakee,Iowa,19005,7,1
+2020-03-29,Appanoose,Iowa,19007,1,0
+2020-03-29,Benton,Iowa,19011,4,0
+2020-03-29,Black Hawk,Iowa,19013,6,0
+2020-03-29,Boone,Iowa,19015,1,0
+2020-03-29,Buchanan,Iowa,19019,2,0
+2020-03-29,Butler,Iowa,19023,1,0
+2020-03-29,Carroll,Iowa,19027,1,0
+2020-03-29,Cedar,Iowa,19031,7,0
+2020-03-29,Cerro Gordo,Iowa,19033,6,0
+2020-03-29,Clayton,Iowa,19043,1,0
+2020-03-29,Clinton,Iowa,19045,1,0
+2020-03-29,Dallas,Iowa,19049,17,0
+2020-03-29,Des Moines,Iowa,19057,1,0
+2020-03-29,Dickinson,Iowa,19059,1,0
+2020-03-29,Dubuque,Iowa,19061,16,1
+2020-03-29,Fayette,Iowa,19065,2,0
+2020-03-29,Hancock,Iowa,19081,3,0
+2020-03-29,Hardin,Iowa,19083,1,0
+2020-03-29,Harrison,Iowa,19085,8,0
+2020-03-29,Henry,Iowa,19087,3,0
+2020-03-29,Iowa,Iowa,19095,2,0
+2020-03-29,Jasper,Iowa,19099,4,0
+2020-03-29,Johnson,Iowa,19103,65,0
+2020-03-29,Keokuk,Iowa,19107,1,0
+2020-03-29,Kossuth,Iowa,19109,1,0
+2020-03-29,Linn,Iowa,19113,42,1
+2020-03-29,Mahaska,Iowa,19123,2,0
+2020-03-29,Marshall,Iowa,19127,6,0
+2020-03-29,Monona,Iowa,19133,2,0
+2020-03-29,Montgomery,Iowa,19137,1,0
+2020-03-29,Muscatine,Iowa,19139,10,0
+2020-03-29,Page,Iowa,19145,2,0
+2020-03-29,Polk,Iowa,19153,50,0
+2020-03-29,Pottawattamie,Iowa,19155,3,0
+2020-03-29,Poweshiek,Iowa,19157,5,1
+2020-03-29,Scott,Iowa,19163,10,0
+2020-03-29,Shelby,Iowa,19165,1,0
+2020-03-29,Sioux,Iowa,19167,2,0
+2020-03-29,Story,Iowa,19169,2,0
+2020-03-29,Tama,Iowa,19171,9,0
+2020-03-29,Taylor,Iowa,19173,1,0
+2020-03-29,Wapello,Iowa,19179,1,0
+2020-03-29,Warren,Iowa,19181,1,0
+2020-03-29,Washington,Iowa,19183,13,0
+2020-03-29,Webster,Iowa,19187,1,0
+2020-03-29,Winneshiek,Iowa,19191,3,0
+2020-03-29,Woodbury,Iowa,19193,4,0
+2020-03-29,Wright,Iowa,19197,1,0
+2020-03-29,Bourbon,Kansas,20011,3,0
+2020-03-29,Butler,Kansas,20015,3,0
+2020-03-29,Cherokee,Kansas,20021,2,0
+2020-03-29,Clay,Kansas,20027,1,0
+2020-03-29,Coffey,Kansas,20031,8,0
+2020-03-29,Crawford,Kansas,20037,4,0
+2020-03-29,Doniphan,Kansas,20043,1,0
+2020-03-29,Douglas,Kansas,20045,23,0
+2020-03-29,Finney,Kansas,20055,1,0
+2020-03-29,Ford,Kansas,20057,1,0
+2020-03-29,Franklin,Kansas,20059,6,0
+2020-03-29,Gove,Kansas,20063,1,0
+2020-03-29,Harvey,Kansas,20079,1,0
+2020-03-29,Jackson,Kansas,20085,1,0
+2020-03-29,Jefferson,Kansas,20087,1,0
+2020-03-29,Johnson,Kansas,20091,108,2
+2020-03-29,Leavenworth,Kansas,20103,17,0
+2020-03-29,Linn,Kansas,20107,5,0
+2020-03-29,Lyon,Kansas,20111,7,0
+2020-03-29,McPherson,Kansas,20113,3,0
+2020-03-29,Miami,Kansas,20121,1,0
+2020-03-29,Mitchell,Kansas,20123,3,0
+2020-03-29,Montgomery,Kansas,20125,3,0
+2020-03-29,Morris,Kansas,20127,2,0
+2020-03-29,Neosho,Kansas,20133,1,0
+2020-03-29,Osage,Kansas,20139,1,0
+2020-03-29,Ottawa,Kansas,20143,1,0
+2020-03-29,Pottawatomie,Kansas,20149,1,0
+2020-03-29,Reno,Kansas,20155,7,0
+2020-03-29,Riley,Kansas,20161,2,0
+2020-03-29,Sedgwick,Kansas,20173,42,0
+2020-03-29,Shawnee,Kansas,20177,13,1
+2020-03-29,Stafford,Kansas,20185,1,0
+2020-03-29,Stevens,Kansas,20189,1,0
+2020-03-29,Sumner,Kansas,20191,1,0
+2020-03-29,Woodson,Kansas,20207,1,0
+2020-03-29,Wyandotte,Kansas,20209,55,4
+2020-03-29,Allen,Kentucky,21003,1,0
+2020-03-29,Anderson,Kentucky,21005,2,1
+2020-03-29,Boone,Kentucky,21015,4,0
+2020-03-29,Bourbon,Kentucky,21017,2,1
+2020-03-29,Boyd,Kentucky,21019,4,0
+2020-03-29,Boyle,Kentucky,21021,1,0
+2020-03-29,Bracken,Kentucky,21023,1,0
+2020-03-29,Breathitt,Kentucky,21025,2,0
+2020-03-29,Breckinridge,Kentucky,21027,2,0
+2020-03-29,Bullitt,Kentucky,21029,2,0
+2020-03-29,Butler,Kentucky,21031,1,0
+2020-03-29,Calloway,Kentucky,21035,3,0
+2020-03-29,Campbell,Kentucky,21037,4,0
+2020-03-29,Carroll,Kentucky,21041,1,0
+2020-03-29,Christian,Kentucky,21047,6,0
+2020-03-29,Clark,Kentucky,21049,6,0
+2020-03-29,Daviess,Kentucky,21059,20,0
+2020-03-29,Fayette,Kentucky,21067,75,1
+2020-03-29,Floyd,Kentucky,21071,1,0
+2020-03-29,Franklin,Kentucky,21073,3,0
+2020-03-29,Grant,Kentucky,21081,1,0
+2020-03-29,Grayson,Kentucky,21085,2,0
+2020-03-29,Hardin,Kentucky,21093,5,0
+2020-03-29,Harrison,Kentucky,21097,11,0
+2020-03-29,Henderson,Kentucky,21101,5,0
+2020-03-29,Hopkins,Kentucky,21107,7,1
+2020-03-29,Jefferson,Kentucky,21111,108,4
+2020-03-29,Jessamine,Kentucky,21113,10,0
+2020-03-29,Kenton,Kentucky,21117,19,1
+2020-03-29,Larue,Kentucky,21123,1,0
+2020-03-29,Laurel,Kentucky,21125,1,0
+2020-03-29,Lewis,Kentucky,21135,1,0
+2020-03-29,Logan,Kentucky,21141,2,0
+2020-03-29,Lyon,Kentucky,21143,1,0
+2020-03-29,Madison,Kentucky,21151,7,0
+2020-03-29,Martin,Kentucky,21159,1,0
+2020-03-29,Mason,Kentucky,21161,1,0
+2020-03-29,McCracken,Kentucky,21145,5,0
+2020-03-29,McCreary,Kentucky,21147,1,0
+2020-03-29,Menifee,Kentucky,21165,2,0
+2020-03-29,Mercer,Kentucky,21167,2,0
+2020-03-29,Montgomery,Kentucky,21173,2,0
+2020-03-29,Muhlenberg,Kentucky,21177,2,0
+2020-03-29,Nelson,Kentucky,21179,3,0
+2020-03-29,Nicholas,Kentucky,21181,1,0
+2020-03-29,Oldham,Kentucky,21185,3,0
+2020-03-29,Pulaski,Kentucky,21199,7,0
+2020-03-29,Scott,Kentucky,21209,6,0
+2020-03-29,Shelby,Kentucky,21211,1,0
+2020-03-29,Simpson,Kentucky,21213,2,0
+2020-03-29,Spencer,Kentucky,21215,1,0
+2020-03-29,Taylor,Kentucky,21217,2,0
+2020-03-29,Union,Kentucky,21225,1,0
+2020-03-29,Unknown,Kentucky,,61,0
+2020-03-29,Warren,Kentucky,21227,10,0
+2020-03-29,Washington,Kentucky,21229,2,0
+2020-03-29,Wayne,Kentucky,21231,1,0
+2020-03-29,Webster,Kentucky,21233,1,0
+2020-03-29,Woodford,Kentucky,21239,3,0
+2020-03-29,Acadia,Louisiana,22001,9,1
+2020-03-29,Allen,Louisiana,22003,9,1
+2020-03-29,Ascension,Louisiana,22005,139,2
+2020-03-29,Assumption,Louisiana,22007,14,0
+2020-03-29,Avoyelles,Louisiana,22009,13,0
+2020-03-29,Beauregard,Louisiana,22011,4,0
+2020-03-29,Bienville,Louisiana,22013,3,1
+2020-03-29,Bossier,Louisiana,22015,56,0
+2020-03-29,Caddo,Louisiana,22017,219,5
+2020-03-29,Calcasieu,Louisiana,22019,35,1
+2020-03-29,Caldwell,Louisiana,22021,1,0
+2020-03-29,Catahoula,Louisiana,22025,1,1
+2020-03-29,Claiborne,Louisiana,22027,4,0
+2020-03-29,De Soto,Louisiana,22031,25,1
+2020-03-29,East Baton Rouge,Louisiana,22033,164,7
+2020-03-29,East Carroll,Louisiana,22035,1,0
+2020-03-29,East Feliciana,Louisiana,22037,8,0
+2020-03-29,Evangeline,Louisiana,22039,4,0
+2020-03-29,Franklin,Louisiana,22041,4,0
+2020-03-29,Grant,Louisiana,22043,2,0
+2020-03-29,Iberia,Louisiana,22045,11,0
+2020-03-29,Iberville,Louisiana,22047,22,1
+2020-03-29,Jackson,Louisiana,22049,2,0
+2020-03-29,Jefferson,Louisiana,22051,761,28
+2020-03-29,Jefferson Davis,Louisiana,22053,2,0
+2020-03-29,LaSalle,Louisiana,22059,2,0
+2020-03-29,Lafayette,Louisiana,22055,50,1
+2020-03-29,Lafourche,Louisiana,22057,36,2
+2020-03-29,Lincoln,Louisiana,22061,7,0
+2020-03-29,Livingston,Louisiana,22063,15,0
+2020-03-29,Madison,Louisiana,22065,1,0
+2020-03-29,Morehouse,Louisiana,22067,2,0
+2020-03-29,Natchitoches,Louisiana,22069,2,0
+2020-03-29,Orleans,Louisiana,22071,1350,73
+2020-03-29,Ouachita,Louisiana,22073,41,1
+2020-03-29,Plaquemines,Louisiana,22075,20,2
+2020-03-29,Pointe Coupee,Louisiana,22077,2,0
+2020-03-29,Rapides,Louisiana,22079,41,1
+2020-03-29,Red River,Louisiana,22081,1,0
+2020-03-29,Richland,Louisiana,22083,2,0
+2020-03-29,Sabine,Louisiana,22085,1,0
+2020-03-29,St. Bernard,Louisiana,22087,45,2
+2020-03-29,St. Charles,Louisiana,22089,31,2
+2020-03-29,St. James,Louisiana,22093,55,3
+2020-03-29,St. John the Baptist,Louisiana,22095,57,5
+2020-03-29,St. Landry,Louisiana,22097,10,0
+2020-03-29,St. Martin,Louisiana,22099,13,3
+2020-03-29,St. Mary,Louisiana,22101,7,0
+2020-03-29,St. Tammany,Louisiana,22103,138,3
+2020-03-29,Tangipahoa,Louisiana,22105,10,0
+2020-03-29,Terrebonne,Louisiana,22109,29,1
+2020-03-29,Union,Louisiana,22111,9,0
+2020-03-29,Unknown,Louisiana,,12,1
+2020-03-29,Vermilion,Louisiana,22113,2,1
+2020-03-29,Vernon,Louisiana,22115,2,0
+2020-03-29,Washington,Louisiana,22117,12,1
+2020-03-29,Webster,Louisiana,22119,9,1
+2020-03-29,West Baton Rouge,Louisiana,22121,12,1
+2020-03-29,West Feliciana,Louisiana,22125,4,0
+2020-03-29,Winn,Louisiana,22127,1,0
+2020-03-29,Androscoggin,Maine,23001,8,0
+2020-03-29,Cumberland,Maine,23005,142,2
+2020-03-29,Franklin,Maine,23007,2,0
+2020-03-29,Kennebec,Maine,23011,10,0
+2020-03-29,Knox,Maine,23013,4,0
+2020-03-29,Lincoln,Maine,23015,5,0
+2020-03-29,Oxford,Maine,23017,9,0
+2020-03-29,Penobscot,Maine,23019,11,0
+2020-03-29,Sagadahoc,Maine,23023,7,0
+2020-03-29,Somerset,Maine,23025,1,0
+2020-03-29,Unknown,Maine,,5,1
+2020-03-29,Waldo,Maine,23027,2,0
+2020-03-29,York,Maine,23031,47,0
+2020-03-29,Anne Arundel,Maryland,24003,99,1
+2020-03-29,Baltimore,Maryland,24005,162,1
+2020-03-29,Baltimore city,Maryland,24510,129,2
+2020-03-29,Calvert,Maryland,24009,14,0
+2020-03-29,Caroline,Maryland,24011,3,0
+2020-03-29,Carroll,Maryland,24013,83,1
+2020-03-29,Cecil,Maryland,24015,13,0
+2020-03-29,Charles,Maryland,24017,28,1
+2020-03-29,Frederick,Maryland,24021,24,0
+2020-03-29,Garrett,Maryland,24023,3,0
+2020-03-29,Harford,Maryland,24025,23,0
+2020-03-29,Howard,Maryland,24027,81,0
+2020-03-29,Kent,Maryland,24029,3,0
+2020-03-29,Montgomery,Maryland,24031,301,1
+2020-03-29,Prince George's,Maryland,24033,247,3
+2020-03-29,Queen Anne's,Maryland,24035,4,0
+2020-03-29,Somerset,Maryland,24039,1,0
+2020-03-29,St. Mary's,Maryland,24037,9,0
+2020-03-29,Talbot,Maryland,24041,3,0
+2020-03-29,Washington,Maryland,24043,6,0
+2020-03-29,Wicomico,Maryland,24045,6,1
+2020-03-29,Worcester,Maryland,24047,2,0
+2020-03-29,Barnstable,Massachusetts,25001,148,2
+2020-03-29,Berkshire,Massachusetts,25003,151,5
+2020-03-29,Bristol,Massachusetts,25005,208,1
+2020-03-29,Dukes,Massachusetts,25007,1,0
+2020-03-29,Essex,Massachusetts,25009,570,4
+2020-03-29,Franklin,Massachusetts,25011,41,2
+2020-03-29,Hampden,Massachusetts,25013,201,5
+2020-03-29,Hampshire,Massachusetts,25015,37,0
+2020-03-29,Middlesex,Massachusetts,25017,981,7
+2020-03-29,Nantucket,Massachusetts,25019,5,0
+2020-03-29,Norfolk,Massachusetts,25021,548,9
+2020-03-29,Plymouth,Massachusetts,25023,325,0
+2020-03-29,Suffolk,Massachusetts,25025,940,4
+2020-03-29,Unknown,Massachusetts,,462,4
+2020-03-29,Worcester,Massachusetts,25027,337,5
+2020-03-29,Allegan,Michigan,26005,2,0
+2020-03-29,Barry,Michigan,26015,1,0
+2020-03-29,Bay,Michigan,26017,5,0
+2020-03-29,Berrien,Michigan,26021,29,0
+2020-03-29,Calhoun,Michigan,26025,15,0
+2020-03-29,Cass,Michigan,26027,4,0
+2020-03-29,Charlevoix,Michigan,26029,4,0
+2020-03-29,Cheboygan,Michigan,26031,1,0
+2020-03-29,Chippewa,Michigan,26033,1,0
+2020-03-29,Clare,Michigan,26035,1,0
+2020-03-29,Clinton,Michigan,26037,14,0
+2020-03-29,Crawford,Michigan,26039,1,0
+2020-03-29,Eaton,Michigan,26045,8,0
+2020-03-29,Emmet,Michigan,26047,4,0
+2020-03-29,Genesee,Michigan,26049,127,5
+2020-03-29,Gladwin,Michigan,26051,3,0
+2020-03-29,Gogebic,Michigan,26053,1,1
+2020-03-29,Grand Traverse,Michigan,26055,6,0
+2020-03-29,Gratiot,Michigan,26057,3,0
+2020-03-29,Hillsdale,Michigan,26059,10,1
+2020-03-29,Huron,Michigan,26063,3,0
+2020-03-29,Ingham,Michigan,26065,43,0
+2020-03-29,Ionia,Michigan,26067,2,0
+2020-03-29,Iosco,Michigan,26069,1,0
+2020-03-29,Isabella,Michigan,26073,4,1
+2020-03-29,Jackson,Michigan,26075,28,1
+2020-03-29,Kalamazoo,Michigan,26077,19,0
+2020-03-29,Kalkaska,Michigan,26079,4,0
+2020-03-29,Kent,Michigan,26081,72,1
+2020-03-29,Lapeer,Michigan,26087,4,0
+2020-03-29,Leelanau,Michigan,26089,1,0
+2020-03-29,Lenawee,Michigan,26091,15,0
+2020-03-29,Livingston,Michigan,26093,59,2
+2020-03-29,Macomb,Michigan,26099,620,20
+2020-03-29,Manistee,Michigan,26101,1,0
+2020-03-29,Marquette,Michigan,26103,2,0
+2020-03-29,Mecosta,Michigan,26107,1,1
+2020-03-29,Midland,Michigan,26111,8,0
+2020-03-29,Missaukee,Michigan,26113,1,1
+2020-03-29,Monroe,Michigan,26115,38,0
+2020-03-29,Montcalm,Michigan,26117,3,0
+2020-03-29,Muskegon,Michigan,26121,13,2
+2020-03-29,Newaygo,Michigan,26123,1,0
+2020-03-29,Oakland,Michigan,26125,1170,34
+2020-03-29,Oceana,Michigan,26127,2,0
+2020-03-29,Ogemaw,Michigan,26129,1,0
+2020-03-29,Osceola,Michigan,26133,2,0
+2020-03-29,Otsego,Michigan,26137,17,0
+2020-03-29,Ottawa,Michigan,26139,25,0
+2020-03-29,Roscommon,Michigan,26143,1,0
+2020-03-29,Saginaw,Michigan,26145,24,0
+2020-03-29,Sanilac,Michigan,26151,2,0
+2020-03-29,Shiawassee,Michigan,26155,5,0
+2020-03-29,St. Clair,Michigan,26147,20,0
+2020-03-29,Tuscola,Michigan,26157,4,1
+2020-03-29,Unknown,Michigan,,77,0
+2020-03-29,Van Buren,Michigan,26159,4,0
+2020-03-29,Washtenaw,Michigan,26161,231,5
+2020-03-29,Wayne,Michigan,26163,2704,56
+2020-03-29,Wexford,Michigan,26165,1,0
+2020-03-29,Anoka,Minnesota,27003,17,0
+2020-03-29,Beltrami,Minnesota,27007,2,0
+2020-03-29,Benton,Minnesota,27009,1,0
+2020-03-29,Big Stone,Minnesota,27011,1,0
+2020-03-29,Blue Earth,Minnesota,27013,8,0
+2020-03-29,Carver,Minnesota,27019,9,0
+2020-03-29,Cass,Minnesota,27021,1,0
+2020-03-29,Chisago,Minnesota,27025,2,0
+2020-03-29,Clay,Minnesota,27027,4,0
+2020-03-29,Clearwater,Minnesota,27029,1,0
+2020-03-29,Cottonwood,Minnesota,27033,1,0
+2020-03-29,Dakota,Minnesota,27037,39,0
+2020-03-29,Dodge,Minnesota,27039,7,0
+2020-03-29,Douglas,Minnesota,27041,1,0
+2020-03-29,Faribault,Minnesota,27043,1,0
+2020-03-29,Fillmore,Minnesota,27045,6,0
+2020-03-29,Goodhue,Minnesota,27049,2,0
+2020-03-29,Hennepin,Minnesota,27053,171,5
+2020-03-29,Isanti,Minnesota,27059,1,0
+2020-03-29,Jackson,Minnesota,27063,1,0
+2020-03-29,Kandiyohi,Minnesota,27067,1,0
+2020-03-29,Lac qui Parle,Minnesota,27073,1,0
+2020-03-29,Le Sueur,Minnesota,27079,11,0
+2020-03-29,Lincoln,Minnesota,27081,1,0
+2020-03-29,Mahnomen,Minnesota,27087,1,0
+2020-03-29,Martin,Minnesota,27091,21,2
+2020-03-29,Mower,Minnesota,27099,11,0
+2020-03-29,Nicollet,Minnesota,27103,3,0
+2020-03-29,Olmsted,Minnesota,27109,47,0
+2020-03-29,Otter Tail,Minnesota,27111,1,0
+2020-03-29,Ramsey,Minnesota,27123,46,2
+2020-03-29,Renville,Minnesota,27129,1,0
+2020-03-29,Rice,Minnesota,27131,3,0
+2020-03-29,Scott,Minnesota,27139,9,0
+2020-03-29,Sherburne,Minnesota,27141,5,0
+2020-03-29,Sibley,Minnesota,27143,1,0
+2020-03-29,St. Louis,Minnesota,27137,10,0
+2020-03-29,Stearns,Minnesota,27145,5,0
+2020-03-29,Steele,Minnesota,27147,5,0
+2020-03-29,Unknown,Minnesota,,1,0
+2020-03-29,Wabasha,Minnesota,27157,4,0
+2020-03-29,Waseca,Minnesota,27161,3,0
+2020-03-29,Washington,Minnesota,27163,27,0
+2020-03-29,Wilkin,Minnesota,27167,1,0
+2020-03-29,Winona,Minnesota,27169,4,0
+2020-03-29,Wright,Minnesota,27171,6,0
+2020-03-29,Adams,Mississippi,28001,7,0
+2020-03-29,Amite,Mississippi,28005,4,0
+2020-03-29,Attala,Mississippi,28007,9,0
+2020-03-29,Benton,Mississippi,28009,4,0
+2020-03-29,Bolivar,Mississippi,28011,11,0
+2020-03-29,Calhoun,Mississippi,28013,3,0
+2020-03-29,Carroll,Mississippi,28015,1,0
+2020-03-29,Chickasaw,Mississippi,28017,10,0
+2020-03-29,Choctaw,Mississippi,28019,5,0
+2020-03-29,Claiborne,Mississippi,28021,1,0
+2020-03-29,Clarke,Mississippi,28023,1,0
+2020-03-29,Clay,Mississippi,28025,2,0
+2020-03-29,Coahoma,Mississippi,28027,18,0
+2020-03-29,Copiah,Mississippi,28029,8,0
+2020-03-29,Covington,Mississippi,28031,1,0
+2020-03-29,DeSoto,Mississippi,28033,71,1
+2020-03-29,Forrest,Mississippi,28035,19,0
+2020-03-29,Franklin,Mississippi,28037,3,0
+2020-03-29,George,Mississippi,28039,3,0
+2020-03-29,Grenada,Mississippi,28043,3,0
+2020-03-29,Hancock,Mississippi,28045,15,1
+2020-03-29,Harrison,Mississippi,28047,43,1
+2020-03-29,Hinds,Mississippi,28049,66,0
+2020-03-29,Holmes,Mississippi,28051,13,1
+2020-03-29,Humphreys,Mississippi,28053,2,0
+2020-03-29,Itawamba,Mississippi,28057,3,0
+2020-03-29,Jackson,Mississippi,28059,34,0
+2020-03-29,Jefferson,Mississippi,28063,1,0
+2020-03-29,Jones,Mississippi,28067,5,0
+2020-03-29,Kemper,Mississippi,28069,1,0
+2020-03-29,Lafayette,Mississippi,28071,13,0
+2020-03-29,Lamar,Mississippi,28073,4,0
+2020-03-29,Lauderdale,Mississippi,28075,15,0
+2020-03-29,Lawrence,Mississippi,28077,5,0
+2020-03-29,Leake,Mississippi,28079,5,0
+2020-03-29,Lee,Mississippi,28081,21,1
+2020-03-29,Leflore,Mississippi,28083,15,0
+2020-03-29,Lincoln,Mississippi,28085,9,0
+2020-03-29,Lowndes,Mississippi,28087,10,0
+2020-03-29,Madison,Mississippi,28089,37,0
+2020-03-29,Marion,Mississippi,28091,4,0
+2020-03-29,Marshall,Mississippi,28093,13,0
+2020-03-29,Monroe,Mississippi,28095,5,0
+2020-03-29,Montgomery,Mississippi,28097,6,0
+2020-03-29,Neshoba,Mississippi,28099,4,0
+2020-03-29,Newton,Mississippi,28101,1,0
+2020-03-29,Noxubee,Mississippi,28103,2,0
+2020-03-29,Oktibbeha,Mississippi,28105,15,0
+2020-03-29,Panola,Mississippi,28107,5,0
+2020-03-29,Pearl River,Mississippi,28109,27,0
+2020-03-29,Perry,Mississippi,28111,2,1
+2020-03-29,Pike,Mississippi,28113,14,0
+2020-03-29,Pontotoc,Mississippi,28115,4,0
+2020-03-29,Prentiss,Mississippi,28117,4,0
+2020-03-29,Quitman,Mississippi,28119,4,0
+2020-03-29,Rankin,Mississippi,28121,35,1
+2020-03-29,Scott,Mississippi,28123,7,0
+2020-03-29,Sharkey,Mississippi,28125,1,0
+2020-03-29,Simpson,Mississippi,28127,2,0
+2020-03-29,Smith,Mississippi,28129,1,0
+2020-03-29,Sunflower,Mississippi,28133,10,1
+2020-03-29,Tallahatchie,Mississippi,28135,2,0
+2020-03-29,Tate,Mississippi,28137,9,0
+2020-03-29,Tippah,Mississippi,28139,23,2
+2020-03-29,Tunica,Mississippi,28143,6,1
+2020-03-29,Union,Mississippi,28145,3,0
+2020-03-29,Walthall,Mississippi,28147,5,0
+2020-03-29,Warren,Mississippi,28149,1,0
+2020-03-29,Washington,Mississippi,28151,16,0
+2020-03-29,Webster,Mississippi,28155,3,1
+2020-03-29,Wilkinson,Mississippi,28157,12,2
+2020-03-29,Winston,Mississippi,28159,4,0
+2020-03-29,Yalobusha,Mississippi,28161,3,0
+2020-03-29,Yazoo,Mississippi,28163,5,0
+2020-03-29,Adair,Missouri,29001,2,0
+2020-03-29,Atchison,Missouri,29005,1,0
+2020-03-29,Barry,Missouri,29009,1,0
+2020-03-29,Bates,Missouri,29013,2,0
+2020-03-29,Benton,Missouri,29015,1,0
+2020-03-29,Bollinger,Missouri,29017,1,0
+2020-03-29,Boone,Missouri,29019,50,1
+2020-03-29,Buchanan,Missouri,29021,3,0
+2020-03-29,Callaway,Missouri,29027,8,0
+2020-03-29,Camden,Missouri,29029,7,1
+2020-03-29,Cape Girardeau,Missouri,29031,6,0
+2020-03-29,Carter,Missouri,29035,2,0
+2020-03-29,Cass,Missouri,29037,8,0
+2020-03-29,Chariton,Missouri,29041,1,0
+2020-03-29,Christian,Missouri,29043,7,0
+2020-03-29,Clay,Missouri,29047,11,0
+2020-03-29,Clinton,Missouri,29049,1,0
+2020-03-29,Cole,Missouri,29051,17,0
+2020-03-29,Cooper,Missouri,29053,1,0
+2020-03-29,Dunklin,Missouri,29069,3,0
+2020-03-29,Franklin,Missouri,29071,7,0
+2020-03-29,Greene,Missouri,29077,41,3
+2020-03-29,Henry,Missouri,29083,1,1
+2020-03-29,Jackson,Missouri,29095,48,1
+2020-03-29,Jasper,Missouri,29097,2,0
+2020-03-29,Jefferson,Missouri,29099,17,0
+2020-03-29,Johnson,Missouri,29101,9,0
+2020-03-29,Kansas City,Missouri,,102,0
+2020-03-29,Lafayette,Missouri,29107,4,0
+2020-03-29,Lincoln,Missouri,29113,2,0
+2020-03-29,McDonald,Missouri,29119,1,0
+2020-03-29,Moniteau,Missouri,29135,4,0
+2020-03-29,Montgomery,Missouri,29139,3,0
+2020-03-29,Newton,Missouri,29145,4,0
+2020-03-29,Pemiscot,Missouri,29155,1,0
+2020-03-29,Perry,Missouri,29157,7,0
+2020-03-29,Pettis,Missouri,29159,1,0
+2020-03-29,Platte,Missouri,29165,6,0
+2020-03-29,Pulaski,Missouri,29169,5,0
+2020-03-29,Ralls,Missouri,29173,1,0
+2020-03-29,Randolph,Missouri,29175,1,0
+2020-03-29,Ray,Missouri,29177,1,0
+2020-03-29,Ripley,Missouri,29181,2,0
+2020-03-29,Scott,Missouri,29201,3,0
+2020-03-29,Shelby,Missouri,29205,1,0
+2020-03-29,St. Charles,Missouri,29183,43,2
+2020-03-29,St. Francois,Missouri,29187,4,0
+2020-03-29,St. Louis,Missouri,29189,336,2
+2020-03-29,St. Louis city,Missouri,29510,97,1
+2020-03-29,Stoddard,Missouri,29207,2,0
+2020-03-29,Taney,Missouri,29213,2,0
+2020-03-29,Texas,Missouri,29215,1,0
+2020-03-29,Unknown,Missouri,,8,0
+2020-03-29,Warren,Missouri,29219,2,0
+2020-03-29,Wright,Missouri,29229,3,0
+2020-03-29,Broadwater,Montana,30007,3,0
+2020-03-29,Cascade,Montana,30013,7,0
+2020-03-29,Deer Lodge,Montana,30023,1,0
+2020-03-29,Flathead,Montana,30029,8,0
+2020-03-29,Gallatin,Montana,30031,62,0
+2020-03-29,Hill,Montana,30041,1,0
+2020-03-29,Jefferson,Montana,30043,2,0
+2020-03-29,Lake,Montana,30047,3,0
+2020-03-29,Lewis and Clark,Montana,30049,10,0
+2020-03-29,Lincoln,Montana,30053,4,1
+2020-03-29,Madison,Montana,30057,4,0
+2020-03-29,Meagher,Montana,30059,1,0
+2020-03-29,Missoula,Montana,30063,11,0
+2020-03-29,Park,Montana,30067,2,0
+2020-03-29,Ravalli,Montana,30081,1,0
+2020-03-29,Roosevelt,Montana,30085,1,0
+2020-03-29,Silver Bow,Montana,30093,9,0
+2020-03-29,Toole,Montana,30101,5,0
+2020-03-29,Yellowstone,Montana,30111,26,0
+2020-03-29,Adams,Nebraska,31001,2,0
+2020-03-29,Buffalo,Nebraska,31019,5,0
+2020-03-29,Cass,Nebraska,31025,2,0
+2020-03-29,Dawson,Nebraska,31047,1,0
+2020-03-29,Dodge,Nebraska,31053,3,0
+2020-03-29,Douglas,Nebraska,31055,79,1
+2020-03-29,Gosper,Nebraska,31073,1,0
+2020-03-29,Hall,Nebraska,31079,6,1
+2020-03-29,Hamilton,Nebraska,31081,1,0
+2020-03-29,Kearney,Nebraska,31099,1,0
+2020-03-29,Knox,Nebraska,31107,2,0
+2020-03-29,Lancaster,Nebraska,31109,6,0
+2020-03-29,Lincoln,Nebraska,31111,3,0
+2020-03-29,Madison,Nebraska,31119,2,0
+2020-03-29,Nemaha,Nebraska,31127,1,0
+2020-03-29,Platte,Nebraska,31141,1,0
+2020-03-29,Sarpy,Nebraska,31153,11,0
+2020-03-29,Saunders,Nebraska,31155,2,0
+2020-03-29,Scotts Bluff,Nebraska,31157,1,0
+2020-03-29,Unknown,Nebraska,,2,0
+2020-03-29,Washington,Nebraska,31177,9,0
+2020-03-29,Carson City,Nevada,32510,5,0
+2020-03-29,Clark,Nevada,32003,528,14
+2020-03-29,Douglas,Nevada,32005,5,0
+2020-03-29,Elko,Nevada,32007,3,0
+2020-03-29,Humboldt,Nevada,32013,1,0
+2020-03-29,Lyon,Nevada,32019,1,0
+2020-03-29,Nye,Nevada,32023,1,0
+2020-03-29,Unknown,Nevada,,269,0
+2020-03-29,Washoe,Nevada,32031,107,1
+2020-03-29,Belknap,New Hampshire,33001,9,0
+2020-03-29,Carroll,New Hampshire,33003,10,0
+2020-03-29,Cheshire,New Hampshire,33005,3,0
+2020-03-29,Grafton,New Hampshire,33009,30,0
+2020-03-29,Hillsborough,New Hampshire,33011,68,2
+2020-03-29,Merrimack,New Hampshire,33013,18,0
+2020-03-29,Rockingham,New Hampshire,33015,100,1
+2020-03-29,Strafford,New Hampshire,33017,17,0
+2020-03-29,Sullivan,New Hampshire,33019,3,0
+2020-03-29,Atlantic,New Jersey,34001,24,0
+2020-03-29,Bergen,New Jersey,34003,2169,35
+2020-03-29,Burlington,New Jersey,34005,142,3
+2020-03-29,Camden,New Jersey,34007,163,1
+2020-03-29,Cape May,New Jersey,34009,9,0
+2020-03-29,Cumberland,New Jersey,34011,11,1
+2020-03-29,Essex,New Jersey,34013,1227,20
+2020-03-29,Gloucester,New Jersey,34015,72,1
+2020-03-29,Hudson,New Jersey,34017,974,6
+2020-03-29,Hunterdon,New Jersey,34019,66,0
+2020-03-29,Mercer,New Jersey,34021,202,0
+2020-03-29,Middlesex,New Jersey,34023,938,14
+2020-03-29,Monmouth,New Jersey,34025,870,10
+2020-03-29,Morris,New Jersey,34027,566,12
+2020-03-29,Ocean,New Jersey,34029,759,9
+2020-03-29,Passaic,New Jersey,34031,831,7
+2020-03-29,Salem,New Jersey,34033,3,0
+2020-03-29,Somerset,New Jersey,34035,295,8
+2020-03-29,Sussex,New Jersey,34037,93,1
+2020-03-29,Union,New Jersey,34039,896,10
+2020-03-29,Unknown,New Jersey,,3020,21
+2020-03-29,Warren,New Jersey,34041,56,2
+2020-03-29,Bernalillo,New Mexico,35001,101,1
+2020-03-29,Chaves,New Mexico,35005,8,0
+2020-03-29,Cibola,New Mexico,35006,2,0
+2020-03-29,Curry,New Mexico,35009,3,0
+2020-03-29,Doña Ana,New Mexico,35013,17,0
+2020-03-29,Eddy,New Mexico,35015,4,1
+2020-03-29,Lea,New Mexico,35025,2,0
+2020-03-29,McKinley,New Mexico,35031,9,0
+2020-03-29,Rio Arriba,New Mexico,35039,2,0
+2020-03-29,Roosevelt,New Mexico,35041,1,0
+2020-03-29,San Juan,New Mexico,35045,22,0
+2020-03-29,San Miguel,New Mexico,35047,1,0
+2020-03-29,Sandoval,New Mexico,35043,18,0
+2020-03-29,Santa Fe,New Mexico,35049,34,0
+2020-03-29,Socorro,New Mexico,35053,2,0
+2020-03-29,Taos,New Mexico,35055,9,0
+2020-03-29,Valencia,New Mexico,35061,2,0
+2020-03-29,Albany,New York,36001,205,1
+2020-03-29,Allegany,New York,36003,6,0
+2020-03-29,Broome,New York,36007,29,3
+2020-03-29,Cattaraugus,New York,36009,4,0
+2020-03-29,Cayuga,New York,36011,2,0
+2020-03-29,Chautauqua,New York,36013,5,0
+2020-03-29,Chemung,New York,36015,15,0
+2020-03-29,Chenango,New York,36017,15,0
+2020-03-29,Clinton,New York,36019,13,0
+2020-03-29,Columbia,New York,36021,23,1
+2020-03-29,Cortland,New York,36023,6,0
+2020-03-29,Delaware,New York,36025,8,0
+2020-03-29,Dutchess,New York,36027,320,2
+2020-03-29,Erie,New York,36029,380,6
+2020-03-29,Essex,New York,36031,4,0
+2020-03-29,Franklin,New York,36033,6,0
+2020-03-29,Fulton,New York,36035,1,0
+2020-03-29,Genesee,New York,36037,9,0
+2020-03-29,Greene,New York,36039,7,0
+2020-03-29,Hamilton,New York,36041,2,0
+2020-03-29,Herkimer,New York,36043,10,0
+2020-03-29,Jefferson,New York,36045,7,0
+2020-03-29,Lewis,New York,36049,2,0
+2020-03-29,Livingston,New York,36051,10,0
+2020-03-29,Madison,New York,36053,24,0
+2020-03-29,Monroe,New York,36055,219,6
+2020-03-29,Montgomery,New York,36057,6,0
+2020-03-29,Nassau,New York,36059,6445,39
+2020-03-29,New York City,New York,,33768,776
+2020-03-29,Niagara,New York,36063,38,0
+2020-03-29,Oneida,New York,36065,26,0
+2020-03-29,Onondaga,New York,36067,152,0
+2020-03-29,Ontario,New York,36069,18,0
+2020-03-29,Orange,New York,36071,1247,3
+2020-03-29,Orleans,New York,36073,3,0
+2020-03-29,Oswego,New York,36075,8,0
+2020-03-29,Otsego,New York,36077,10,0
+2020-03-29,Putnam,New York,36079,144,0
+2020-03-29,Rensselaer,New York,36083,39,0
+2020-03-29,Rockland,New York,36087,2209,8
+2020-03-29,Saratoga,New York,36091,102,1
+2020-03-29,Schenectady,New York,36093,76,0
+2020-03-29,Schoharie,New York,36095,5,0
+2020-03-29,Schuyler,New York,36097,1,0
+2020-03-29,St. Lawrence,New York,36089,12,0
+2020-03-29,Steuben,New York,36101,17,0
+2020-03-29,Suffolk,New York,36103,5023,40
+2020-03-29,Sullivan,New York,36105,88,0
+2020-03-29,Tioga,New York,36107,4,0
+2020-03-29,Tompkins,New York,36109,52,0
+2020-03-29,Ulster,New York,36111,179,1
+2020-03-29,Warren,New York,36113,18,0
+2020-03-29,Washington,New York,36115,7,0
+2020-03-29,Wayne,New York,36117,12,0
+2020-03-29,Westchester,New York,36119,8519,10
+2020-03-29,Wyoming,New York,36121,8,0
+2020-03-29,Alamance,North Carolina,37001,6,0
+2020-03-29,Alleghany,North Carolina,37005,1,0
+2020-03-29,Beaufort,North Carolina,37013,3,0
+2020-03-29,Bertie,North Carolina,37015,3,0
+2020-03-29,Bladen,North Carolina,37017,1,0
+2020-03-29,Brunswick,North Carolina,37019,12,0
+2020-03-29,Buncombe,North Carolina,37021,19,1
+2020-03-29,Burke,North Carolina,37023,4,0
+2020-03-29,Cabarrus,North Carolina,37025,29,1
+2020-03-29,Caldwell,North Carolina,37027,3,0
+2020-03-29,Carteret,North Carolina,37031,8,0
+2020-03-29,Caswell,North Carolina,37033,1,0
+2020-03-29,Catawba,North Carolina,37035,14,0
+2020-03-29,Chatham,North Carolina,37037,13,0
+2020-03-29,Cherokee,North Carolina,37039,6,0
+2020-03-29,Cleveland,North Carolina,37045,5,0
+2020-03-29,Columbus,North Carolina,37047,1,0
+2020-03-29,Craven,North Carolina,37049,5,0
+2020-03-29,Cumberland,North Carolina,37051,13,0
+2020-03-29,Currituck,North Carolina,37053,1,0
+2020-03-29,Davidson,North Carolina,37057,16,0
+2020-03-29,Davie,North Carolina,37059,6,0
+2020-03-29,Duplin,North Carolina,37061,1,0
+2020-03-29,Durham,North Carolina,37063,105,0
+2020-03-29,Edgecombe,North Carolina,37065,1,0
+2020-03-29,Forsyth,North Carolina,37067,35,0
+2020-03-29,Franklin,North Carolina,37069,5,0
+2020-03-29,Gaston,North Carolina,37071,21,0
+2020-03-29,Granville,North Carolina,37077,6,0
+2020-03-29,Greene,North Carolina,37079,3,0
+2020-03-29,Guilford,North Carolina,37081,39,0
+2020-03-29,Halifax,North Carolina,37083,2,0
+2020-03-29,Harnett,North Carolina,37085,14,1
+2020-03-29,Henderson,North Carolina,37089,13,0
+2020-03-29,Hertford,North Carolina,37091,2,0
+2020-03-29,Hoke,North Carolina,37093,3,0
+2020-03-29,Iredell,North Carolina,37097,21,0
+2020-03-29,Jackson,North Carolina,37099,1,0
+2020-03-29,Johnston,North Carolina,37101,10,1
+2020-03-29,Lee,North Carolina,37105,2,0
+2020-03-29,Lenoir,North Carolina,37107,3,0
+2020-03-29,Lincoln,North Carolina,37109,3,0
+2020-03-29,McDowell,North Carolina,37111,4,0
+2020-03-29,Mecklenburg,North Carolina,37119,336,1
+2020-03-29,Montgomery,North Carolina,37123,3,0
+2020-03-29,Moore,North Carolina,37125,6,0
+2020-03-29,Nash,North Carolina,37127,3,0
+2020-03-29,New Hanover,North Carolina,37129,22,0
+2020-03-29,Northampton,North Carolina,37131,25,0
+2020-03-29,Onslow,North Carolina,37133,4,0
+2020-03-29,Orange,North Carolina,37135,29,0
+2020-03-29,Pamlico,North Carolina,37137,1,0
+2020-03-29,Pasquotank,North Carolina,37139,2,0
+2020-03-29,Perquimans,North Carolina,37143,1,0
+2020-03-29,Person,North Carolina,37145,1,0
+2020-03-29,Pitt,North Carolina,37147,15,0
+2020-03-29,Polk,North Carolina,37149,2,0
+2020-03-29,Randolph,North Carolina,37151,15,0
+2020-03-29,Richmond,North Carolina,37153,1,0
+2020-03-29,Robeson,North Carolina,37155,2,0
+2020-03-29,Rowan,North Carolina,37159,17,1
+2020-03-29,Sampson,North Carolina,37163,1,0
+2020-03-29,Scotland,North Carolina,37165,2,0
+2020-03-29,Stanly,North Carolina,37167,5,0
+2020-03-29,Surry,North Carolina,37171,2,0
+2020-03-29,Transylvania,North Carolina,37175,3,0
+2020-03-29,Union,North Carolina,37179,38,0
+2020-03-29,Vance,North Carolina,37181,3,0
+2020-03-29,Wake,North Carolina,37183,146,0
+2020-03-29,Washington,North Carolina,37187,1,0
+2020-03-29,Watauga,North Carolina,37189,5,0
+2020-03-29,Wayne,North Carolina,37191,3,0
+2020-03-29,Wilson,North Carolina,37195,10,0
+2020-03-29,Yadkin,North Carolina,37197,1,0
+2020-03-29,Barnes,North Dakota,38003,2,0
+2020-03-29,Burleigh,North Dakota,38015,28,0
+2020-03-29,Cass,North Dakota,38017,20,1
+2020-03-29,Divide,North Dakota,38023,1,0
+2020-03-29,Dunn,North Dakota,38025,1,0
+2020-03-29,Foster,North Dakota,38031,1,0
+2020-03-29,McHenry,North Dakota,38049,1,0
+2020-03-29,McIntosh,North Dakota,38051,1,0
+2020-03-29,McLean,North Dakota,38055,2,0
+2020-03-29,Mercer,North Dakota,38057,1,0
+2020-03-29,Morton,North Dakota,38059,14,0
+2020-03-29,Mountrail,North Dakota,38061,2,0
+2020-03-29,Pierce,North Dakota,38069,2,0
+2020-03-29,Ramsey,North Dakota,38071,3,0
+2020-03-29,Sioux,North Dakota,38085,1,0
+2020-03-29,Stark,North Dakota,38089,10,0
+2020-03-29,Walsh,North Dakota,38099,1,0
+2020-03-29,Ward,North Dakota,38101,7,0
+2020-03-29,Unknown,Northern Mariana Islands,,2,0
+2020-03-29,Allen,Ohio,39003,4,0
+2020-03-29,Ashland,Ohio,39005,2,0
+2020-03-29,Ashtabula,Ohio,39007,6,0
+2020-03-29,Athens,Ohio,39009,3,0
+2020-03-29,Auglaize,Ohio,39011,2,0
+2020-03-29,Belmont,Ohio,39013,8,0
+2020-03-29,Butler,Ohio,39017,27,0
+2020-03-29,Carroll,Ohio,39019,4,0
+2020-03-29,Champaign,Ohio,39021,2,0
+2020-03-29,Clark,Ohio,39023,7,0
+2020-03-29,Clermont,Ohio,39025,8,0
+2020-03-29,Clinton,Ohio,39027,3,0
+2020-03-29,Columbiana,Ohio,39029,11,1
+2020-03-29,Coshocton,Ohio,39031,4,0
+2020-03-29,Crawford,Ohio,39033,2,0
+2020-03-29,Cuyahoga,Ohio,39035,449,4
+2020-03-29,Darke,Ohio,39037,3,0
+2020-03-29,Defiance,Ohio,39039,5,0
+2020-03-29,Delaware,Ohio,39041,31,0
+2020-03-29,Erie,Ohio,39043,5,1
+2020-03-29,Fairfield,Ohio,39045,14,0
+2020-03-29,Fayette,Ohio,39047,1,0
+2020-03-29,Franklin,Ohio,39049,247,2
+2020-03-29,Fulton,Ohio,39051,2,0
+2020-03-29,Gallia,Ohio,39053,1,1
+2020-03-29,Geauga,Ohio,39055,17,0
+2020-03-29,Greene,Ohio,39057,3,0
+2020-03-29,Hamilton,Ohio,39061,85,0
+2020-03-29,Hancock,Ohio,39063,3,0
+2020-03-29,Highland,Ohio,39071,1,0
+2020-03-29,Huron,Ohio,39077,3,0
+2020-03-29,Jefferson,Ohio,39081,5,0
+2020-03-29,Knox,Ohio,39083,3,0
+2020-03-29,Lake,Ohio,39085,35,1
+2020-03-29,Lawrence,Ohio,39087,1,0
+2020-03-29,Licking,Ohio,39089,17,0
+2020-03-29,Logan,Ohio,39091,3,0
+2020-03-29,Lorain,Ohio,39093,74,1
+2020-03-29,Lucas,Ohio,39095,94,2
+2020-03-29,Madison,Ohio,39097,4,0
+2020-03-29,Mahoning,Ohio,39099,84,2
+2020-03-29,Marion,Ohio,39101,6,0
+2020-03-29,Medina,Ohio,39103,45,1
+2020-03-29,Mercer,Ohio,39107,2,0
+2020-03-29,Miami,Ohio,39109,43,5
+2020-03-29,Montgomery,Ohio,39113,25,0
+2020-03-29,Muskingum,Ohio,39119,2,0
+2020-03-29,Ottawa,Ohio,39123,1,0
+2020-03-29,Pickaway,Ohio,39129,4,0
+2020-03-29,Pike,Ohio,39131,1,0
+2020-03-29,Portage,Ohio,39133,27,0
+2020-03-29,Richland,Ohio,39139,5,0
+2020-03-29,Sandusky,Ohio,39143,3,0
+2020-03-29,Seneca,Ohio,39147,2,0
+2020-03-29,Shelby,Ohio,39149,3,0
+2020-03-29,Stark,Ohio,39151,29,2
+2020-03-29,Summit,Ohio,39153,99,5
+2020-03-29,Trumbull,Ohio,39155,36,2
+2020-03-29,Tuscarawas,Ohio,39157,5,0
+2020-03-29,Union,Ohio,39159,3,0
+2020-03-29,Van Wert,Ohio,39161,1,0
+2020-03-29,Warren,Ohio,39165,20,0
+2020-03-29,Washington,Ohio,39167,3,0
+2020-03-29,Wayne,Ohio,39169,4,0
+2020-03-29,Wood,Ohio,39173,12,0
+2020-03-29,Wyandot,Ohio,39175,1,0
+2020-03-29,Adair,Oklahoma,40001,4,0
+2020-03-29,Bryan,Oklahoma,40013,1,0
+2020-03-29,Caddo,Oklahoma,40015,1,0
+2020-03-29,Canadian,Oklahoma,40017,12,0
+2020-03-29,Carter,Oklahoma,40019,1,0
+2020-03-29,Cherokee,Oklahoma,40021,1,0
+2020-03-29,Choctaw,Oklahoma,40023,1,0
+2020-03-29,Cleveland,Oklahoma,40027,51,5
+2020-03-29,Comanche,Oklahoma,40031,11,0
+2020-03-29,Craig,Oklahoma,40035,1,0
+2020-03-29,Creek,Oklahoma,40037,16,1
+2020-03-29,Custer,Oklahoma,40039,4,0
+2020-03-29,Delaware,Oklahoma,40041,4,0
+2020-03-29,Garfield,Oklahoma,40047,2,0
+2020-03-29,Garvin,Oklahoma,40049,4,0
+2020-03-29,Grady,Oklahoma,40051,2,0
+2020-03-29,Jackson,Oklahoma,40065,1,0
+2020-03-29,Kay,Oklahoma,40071,20,0
+2020-03-29,Latimer,Oklahoma,40077,1,0
+2020-03-29,Le Flore,Oklahoma,40079,1,0
+2020-03-29,Lincoln,Oklahoma,40081,3,0
+2020-03-29,Logan,Oklahoma,40083,3,0
+2020-03-29,Mayes,Oklahoma,40097,3,0
+2020-03-29,McClain,Oklahoma,40087,2,0
+2020-03-29,Muskogee,Oklahoma,40101,7,0
+2020-03-29,Noble,Oklahoma,40103,3,0
+2020-03-29,Nowata,Oklahoma,40105,3,0
+2020-03-29,Oklahoma,Oklahoma,40109,120,4
+2020-03-29,Okmulgee,Oklahoma,40111,3,0
+2020-03-29,Osage,Oklahoma,40113,10,0
+2020-03-29,Ottawa,Oklahoma,40115,4,0
+2020-03-29,Pawnee,Oklahoma,40117,15,1
+2020-03-29,Payne,Oklahoma,40119,13,0
+2020-03-29,Pittsburg,Oklahoma,40121,2,0
+2020-03-29,Pontotoc,Oklahoma,40123,3,0
+2020-03-29,Pottawatomie,Oklahoma,40125,2,0
+2020-03-29,Rogers,Oklahoma,40131,1,0
+2020-03-29,Seminole,Oklahoma,40133,1,0
+2020-03-29,Sequoyah,Oklahoma,40135,2,1
+2020-03-29,Stephens,Oklahoma,40137,2,0
+2020-03-29,Texas,Oklahoma,40139,1,0
+2020-03-29,Tulsa,Oklahoma,40143,61,3
+2020-03-29,Wagoner,Oklahoma,40145,8,1
+2020-03-29,Washington,Oklahoma,40147,18,0
+2020-03-29,Benton,Oregon,41003,9,0
+2020-03-29,Clackamas,Oregon,41005,39,2
+2020-03-29,Clatsop,Oregon,41007,3,0
+2020-03-29,Columbia,Oregon,41009,1,0
+2020-03-29,Deschutes,Oregon,41017,23,0
+2020-03-29,Douglas,Oregon,41019,4,0
+2020-03-29,Grant,Oregon,41023,1,0
+2020-03-29,Hood River,Oregon,41027,2,0
+2020-03-29,Jackson,Oregon,41029,19,0
+2020-03-29,Josephine,Oregon,41033,6,0
+2020-03-29,Klamath,Oregon,41035,4,0
+2020-03-29,Lane,Oregon,41039,10,1
+2020-03-29,Lincoln,Oregon,41041,1,0
+2020-03-29,Linn,Oregon,41043,36,1
+2020-03-29,Marion,Oregon,41047,109,3
+2020-03-29,Morrow,Oregon,41049,1,0
+2020-03-29,Multnomah,Oregon,41051,91,2
+2020-03-29,Polk,Oregon,41053,13,0
+2020-03-29,Tillamook,Oregon,41057,2,0
+2020-03-29,Umatilla,Oregon,41059,4,0
+2020-03-29,Union,Oregon,41061,1,0
+2020-03-29,Wasco,Oregon,41065,3,0
+2020-03-29,Washington,Oregon,41067,154,3
+2020-03-29,Yamhill,Oregon,41071,13,1
+2020-03-29,Adams,Pennsylvania,42001,8,0
+2020-03-29,Allegheny,Pennsylvania,42003,265,2
+2020-03-29,Armstrong,Pennsylvania,42005,3,0
+2020-03-29,Beaver,Pennsylvania,42007,28,0
+2020-03-29,Berks,Pennsylvania,42011,68,0
+2020-03-29,Blair,Pennsylvania,42013,3,0
+2020-03-29,Bradford,Pennsylvania,42015,3,0
+2020-03-29,Bucks,Pennsylvania,42017,249,3
+2020-03-29,Butler,Pennsylvania,42019,47,2
+2020-03-29,Cambria,Pennsylvania,42021,1,0
+2020-03-29,Cameron,Pennsylvania,42023,1,0
+2020-03-29,Carbon,Pennsylvania,42025,9,0
+2020-03-29,Centre,Pennsylvania,42027,22,0
+2020-03-29,Chester,Pennsylvania,42029,137,0
+2020-03-29,Clarion,Pennsylvania,42031,1,0
+2020-03-29,Clearfield,Pennsylvania,42033,2,0
+2020-03-29,Columbia,Pennsylvania,42037,6,0
+2020-03-29,Crawford,Pennsylvania,42039,3,0
+2020-03-29,Cumberland,Pennsylvania,42041,22,1
+2020-03-29,Dauphin,Pennsylvania,42043,35,0
+2020-03-29,Delaware,Pennsylvania,42045,276,4
+2020-03-29,Erie,Pennsylvania,42049,7,0
+2020-03-29,Fayette,Pennsylvania,42051,10,0
+2020-03-29,Franklin,Pennsylvania,42055,11,0
+2020-03-29,Greene,Pennsylvania,42059,6,0
+2020-03-29,Huntingdon,Pennsylvania,42061,1,0
+2020-03-29,Indiana,Pennsylvania,42063,2,0
+2020-03-29,Juniata,Pennsylvania,42067,1,0
+2020-03-29,Lackawanna,Pennsylvania,42069,56,2
+2020-03-29,Lancaster,Pennsylvania,42071,67,2
+2020-03-29,Lawrence,Pennsylvania,42073,8,1
+2020-03-29,Lebanon,Pennsylvania,42075,19,0
+2020-03-29,Lehigh,Pennsylvania,42077,151,3
+2020-03-29,Luzerne,Pennsylvania,42079,94,2
+2020-03-29,Lycoming,Pennsylvania,42081,3,0
+2020-03-29,McKean,Pennsylvania,42083,1,0
+2020-03-29,Mercer,Pennsylvania,42085,7,0
+2020-03-29,Mifflin,Pennsylvania,42087,2,0
+2020-03-29,Monroe,Pennsylvania,42089,135,3
+2020-03-29,Montgomery,Pennsylvania,42091,488,5
+2020-03-29,Montour,Pennsylvania,42093,5,0
+2020-03-29,Northampton,Pennsylvania,42095,126,4
+2020-03-29,Northumberland,Pennsylvania,42097,1,0
+2020-03-29,Perry,Pennsylvania,42099,1,0
+2020-03-29,Philadelphia,Pennsylvania,42101,865,5
+2020-03-29,Pike,Pennsylvania,42103,33,1
+2020-03-29,Potter,Pennsylvania,42105,2,0
+2020-03-29,Schuylkill,Pennsylvania,42107,21,0
+2020-03-29,Snyder,Pennsylvania,42109,2,0
+2020-03-29,Somerset,Pennsylvania,42111,2,0
+2020-03-29,Susquehanna,Pennsylvania,42115,1,0
+2020-03-29,Tioga,Pennsylvania,42117,1,0
+2020-03-29,Venango,Pennsylvania,42121,1,0
+2020-03-29,Warren,Pennsylvania,42123,1,0
+2020-03-29,Washington,Pennsylvania,42125,24,0
+2020-03-29,Wayne,Pennsylvania,42127,7,0
+2020-03-29,Westmoreland,Pennsylvania,42129,47,0
+2020-03-29,York,Pennsylvania,42133,43,0
+2020-03-29,Unknown,Puerto Rico,,127,5
+2020-03-29,Bristol,Rhode Island,44001,11,0
+2020-03-29,Kent,Rhode Island,44003,28,0
+2020-03-29,Newport,Rhode Island,44005,17,0
+2020-03-29,Providence,Rhode Island,44007,148,0
+2020-03-29,Unknown,Rhode Island,,106,3
+2020-03-29,Washington,Rhode Island,44009,21,0
+2020-03-29,Abbeville,South Carolina,45001,4,0
+2020-03-29,Aiken,South Carolina,45003,9,0
+2020-03-29,Anderson,South Carolina,45007,29,0
+2020-03-29,Beaufort,South Carolina,45013,50,0
+2020-03-29,Berkeley,South Carolina,45015,13,0
+2020-03-29,Calhoun,South Carolina,45017,2,0
+2020-03-29,Charleston,South Carolina,45019,116,1
+2020-03-29,Chester,South Carolina,45023,2,0
+2020-03-29,Chesterfield,South Carolina,45025,4,0
+2020-03-29,Clarendon,South Carolina,45027,16,1
+2020-03-29,Colleton,South Carolina,45029,4,0
+2020-03-29,Darlington,South Carolina,45031,10,0
+2020-03-29,Dillon,South Carolina,45033,1,0
+2020-03-29,Dorchester,South Carolina,45035,10,0
+2020-03-29,Edgefield,South Carolina,45037,2,0
+2020-03-29,Fairfield,South Carolina,45039,4,0
+2020-03-29,Florence,South Carolina,45041,13,3
+2020-03-29,Georgetown,South Carolina,45043,10,0
+2020-03-29,Greenville,South Carolina,45045,71,1
+2020-03-29,Greenwood,South Carolina,45047,3,0
+2020-03-29,Horry,South Carolina,45051,31,3
+2020-03-29,Jasper,South Carolina,45053,3,0
+2020-03-29,Kershaw,South Carolina,45055,83,2
+2020-03-29,Lancaster,South Carolina,45057,13,0
+2020-03-29,Laurens,South Carolina,45059,3,0
+2020-03-29,Lee,South Carolina,45061,5,0
+2020-03-29,Lexington,South Carolina,45063,35,1
+2020-03-29,Marion,South Carolina,45067,1,0
+2020-03-29,Marlboro,South Carolina,45069,2,0
+2020-03-29,Newberry,South Carolina,45071,2,0
+2020-03-29,Oconee,South Carolina,45073,4,0
+2020-03-29,Orangeburg,South Carolina,45075,16,0
+2020-03-29,Pickens,South Carolina,45077,11,0
+2020-03-29,Richland,South Carolina,45079,98,2
+2020-03-29,Saluda,South Carolina,45081,1,0
+2020-03-29,Spartanburg,South Carolina,45083,25,0
+2020-03-29,Sumter,South Carolina,45085,30,2
+2020-03-29,Union,South Carolina,45087,1,0
+2020-03-29,Williamsburg,South Carolina,45089,2,0
+2020-03-29,York,South Carolina,45091,36,0
+2020-03-29,Aurora,South Dakota,46003,1,0
+2020-03-29,Beadle,South Dakota,46005,20,0
+2020-03-29,Bon Homme,South Dakota,46009,1,0
+2020-03-29,Brookings,South Dakota,46011,1,0
+2020-03-29,Brown,South Dakota,46013,2,0
+2020-03-29,Charles Mix,South Dakota,46023,1,0
+2020-03-29,Clark,South Dakota,46025,1,0
+2020-03-29,Clay,South Dakota,46027,2,0
+2020-03-29,Codington,South Dakota,46029,4,0
+2020-03-29,Davison,South Dakota,46035,2,1
+2020-03-29,Deuel,South Dakota,46039,1,0
+2020-03-29,Fall River,South Dakota,46047,1,0
+2020-03-29,Faulk,South Dakota,46049,1,0
+2020-03-29,Hamlin,South Dakota,46057,1,0
+2020-03-29,Hughes,South Dakota,46065,1,0
+2020-03-29,Hutchinson,South Dakota,46067,2,0
+2020-03-29,Lawrence,South Dakota,46081,3,0
+2020-03-29,Lincoln,South Dakota,46083,4,0
+2020-03-29,Lyman,South Dakota,46085,1,0
+2020-03-29,McCook,South Dakota,46087,2,0
+2020-03-29,Meade,South Dakota,46093,1,0
+2020-03-29,Minnehaha,South Dakota,46099,25,0
+2020-03-29,Pennington,South Dakota,46103,4,0
+2020-03-29,Roberts,South Dakota,46109,1,0
+2020-03-29,Todd,South Dakota,46121,1,0
+2020-03-29,Turner,South Dakota,46125,1,0
+2020-03-29,Union,South Dakota,46127,1,0
+2020-03-29,Yankton,South Dakota,46135,4,0
+2020-03-29,Anderson,Tennessee,47001,6,0
+2020-03-29,Bedford,Tennessee,47003,1,0
+2020-03-29,Benton,Tennessee,47005,3,0
+2020-03-29,Bledsoe,Tennessee,47007,2,0
+2020-03-29,Blount,Tennessee,47009,9,0
+2020-03-29,Bradley,Tennessee,47011,8,0
+2020-03-29,Campbell,Tennessee,47013,4,0
+2020-03-29,Cannon,Tennessee,47015,2,0
+2020-03-29,Carroll,Tennessee,47017,5,0
+2020-03-29,Carter,Tennessee,47019,1,0
+2020-03-29,Cheatham,Tennessee,47021,8,0
+2020-03-29,Chester,Tennessee,47023,2,0
+2020-03-29,Claiborne,Tennessee,47025,2,0
+2020-03-29,Cocke,Tennessee,47029,1,0
+2020-03-29,Coffee,Tennessee,47031,1,0
+2020-03-29,Cumberland,Tennessee,47035,9,0
+2020-03-29,Davidson,Tennessee,47037,394,2
+2020-03-29,DeKalb,Tennessee,47041,3,0
+2020-03-29,Decatur,Tennessee,47039,1,0
+2020-03-29,Dickson,Tennessee,47043,11,0
+2020-03-29,Dyer,Tennessee,47045,3,0
+2020-03-29,Fayette,Tennessee,47047,10,0
+2020-03-29,Franklin,Tennessee,47051,6,0
+2020-03-29,Gibson,Tennessee,47053,3,0
+2020-03-29,Greene,Tennessee,47059,9,0
+2020-03-29,Grundy,Tennessee,47061,2,0
+2020-03-29,Hamblen,Tennessee,47063,2,0
+2020-03-29,Hamilton,Tennessee,47065,35,0
+2020-03-29,Hardeman,Tennessee,47069,1,0
+2020-03-29,Hardin,Tennessee,47071,1,0
+2020-03-29,Hawkins,Tennessee,47073,2,0
+2020-03-29,Haywood,Tennessee,47075,2,0
+2020-03-29,Henry,Tennessee,47079,1,0
+2020-03-29,Houston,Tennessee,47083,2,0
+2020-03-29,Jefferson,Tennessee,47089,5,0
+2020-03-29,Johnson,Tennessee,47091,2,0
+2020-03-29,Knox,Tennessee,47093,38,0
+2020-03-29,Lewis,Tennessee,47101,2,0
+2020-03-29,Lincoln,Tennessee,47103,1,0
+2020-03-29,Loudon,Tennessee,47105,8,0
+2020-03-29,Macon,Tennessee,47111,3,0
+2020-03-29,Madison,Tennessee,47113,3,0
+2020-03-29,Marion,Tennessee,47115,5,0
+2020-03-29,Maury,Tennessee,47119,8,0
+2020-03-29,McMinn,Tennessee,47107,3,0
+2020-03-29,McNairy,Tennessee,47109,1,0
+2020-03-29,Meigs,Tennessee,47121,1,0
+2020-03-29,Monroe,Tennessee,47123,3,0
+2020-03-29,Montgomery,Tennessee,47125,13,0
+2020-03-29,Morgan,Tennessee,47129,1,0
+2020-03-29,Obion,Tennessee,47131,1,0
+2020-03-29,Overton,Tennessee,47133,2,0
+2020-03-29,Perry,Tennessee,47135,2,0
+2020-03-29,Putnam,Tennessee,47141,17,0
+2020-03-29,Roane,Tennessee,47145,2,0
+2020-03-29,Robertson,Tennessee,47147,25,0
+2020-03-29,Rutherford,Tennessee,47149,48,0
+2020-03-29,Scott,Tennessee,47151,2,0
+2020-03-29,Sevier,Tennessee,47155,6,0
+2020-03-29,Shelby,Tennessee,47157,362,1
+2020-03-29,Smith,Tennessee,47159,1,0
+2020-03-29,Sullivan,Tennessee,47163,8,0
+2020-03-29,Sumner,Tennessee,47165,93,0
+2020-03-29,Tipton,Tennessee,47167,15,0
+2020-03-29,Trousdale,Tennessee,47169,1,0
+2020-03-29,Unicoi,Tennessee,47171,1,0
+2020-03-29,Union,Tennessee,47173,1,0
+2020-03-29,Unknown,Tennessee,,190,4
+2020-03-29,Washington,Tennessee,47179,14,0
+2020-03-29,Weakley,Tennessee,47183,1,0
+2020-03-29,White,Tennessee,47185,1,0
+2020-03-29,Williamson,Tennessee,47187,101,0
+2020-03-29,Wilson,Tennessee,47189,27,0
+2020-03-29,Andrews,Texas,48003,1,0
+2020-03-29,Angelina,Texas,48005,3,0
+2020-03-29,Atascosa,Texas,48013,2,0
+2020-03-29,Austin,Texas,48015,2,0
+2020-03-29,Bastrop,Texas,48021,5,0
+2020-03-29,Bell,Texas,48027,28,1
+2020-03-29,Bexar,Texas,48029,140,5
+2020-03-29,Blanco,Texas,48031,1,0
+2020-03-29,Bowie,Texas,48037,3,0
+2020-03-29,Brazoria,Texas,48039,61,0
+2020-03-29,Brazos,Texas,48041,44,2
+2020-03-29,Brown,Texas,48049,3,0
+2020-03-29,Burleson,Texas,48051,1,0
+2020-03-29,Burnet,Texas,48053,1,0
+2020-03-29,Caldwell,Texas,48055,1,0
+2020-03-29,Calhoun,Texas,48057,3,0
+2020-03-29,Cameron,Texas,48061,20,0
+2020-03-29,Cass,Texas,48067,2,0
+2020-03-29,Castro,Texas,48069,8,0
+2020-03-29,Chambers,Texas,48071,3,0
+2020-03-29,Cherokee,Texas,48073,2,0
+2020-03-29,Collin,Texas,48085,128,1
+2020-03-29,Comal,Texas,48091,9,1
+2020-03-29,Cooke,Texas,48097,1,0
+2020-03-29,Coryell,Texas,48099,1,0
+2020-03-29,Crane,Texas,48103,1,0
+2020-03-29,Dallas,Texas,48113,443,9
+2020-03-29,Dawson,Texas,48115,1,0
+2020-03-29,DeWitt,Texas,48123,3,0
+2020-03-29,Deaf Smith,Texas,48117,2,0
+2020-03-29,Denton,Texas,48121,165,2
+2020-03-29,Eastland,Texas,48133,3,0
+2020-03-29,Ector,Texas,48135,3,0
+2020-03-29,El Paso,Texas,48141,40,0
+2020-03-29,Ellis,Texas,48139,15,0
+2020-03-29,Erath,Texas,48143,1,0
+2020-03-29,Falls,Texas,48145,1,0
+2020-03-29,Fannin,Texas,48147,1,0
+2020-03-29,Fayette,Texas,48149,1,0
+2020-03-29,Fort Bend,Texas,48157,119,1
+2020-03-29,Franklin,Texas,48159,1,0
+2020-03-29,Gaines,Texas,48165,1,0
+2020-03-29,Galveston,Texas,48167,70,0
+2020-03-29,Grayson,Texas,48181,3,0
+2020-03-29,Gregg,Texas,48183,4,0
+2020-03-29,Grimes,Texas,48185,2,0
+2020-03-29,Guadalupe,Texas,48187,10,0
+2020-03-29,Hale,Texas,48189,1,0
+2020-03-29,Hardin,Texas,48199,9,1
+2020-03-29,Harris,Texas,48201,526,4
+2020-03-29,Harrison,Texas,48203,1,0
+2020-03-29,Hays,Texas,48209,13,0
+2020-03-29,Henderson,Texas,48213,1,0
+2020-03-29,Hidalgo,Texas,48215,27,0
+2020-03-29,Hockley,Texas,48219,7,0
+2020-03-29,Hood,Texas,48221,2,0
+2020-03-29,Hopkins,Texas,48223,1,0
+2020-03-29,Hunt,Texas,48231,1,0
+2020-03-29,Jackson,Texas,48239,1,0
+2020-03-29,Jefferson,Texas,48245,16,0
+2020-03-29,Johnson,Texas,48251,8,1
+2020-03-29,Karnes,Texas,48255,2,0
+2020-03-29,Kaufman,Texas,48257,2,0
+2020-03-29,Kendall,Texas,48259,7,0
+2020-03-29,Kleberg,Texas,48273,1,0
+2020-03-29,Lamar,Texas,48277,3,0
+2020-03-29,Lamb,Texas,48279,1,0
+2020-03-29,Lavaca,Texas,48285,1,0
+2020-03-29,Liberty,Texas,48291,2,0
+2020-03-29,Limestone,Texas,48293,1,0
+2020-03-29,Llano,Texas,48299,2,0
+2020-03-29,Lubbock,Texas,48303,41,0
+2020-03-29,Lynn,Texas,48305,1,0
+2020-03-29,Martin,Texas,48317,1,0
+2020-03-29,Matagorda,Texas,48321,12,1
+2020-03-29,Maverick,Texas,48323,1,0
+2020-03-29,McLennan,Texas,48309,36,0
+2020-03-29,Medina,Texas,48325,3,0
+2020-03-29,Midland,Texas,48329,11,1
+2020-03-29,Milam,Texas,48331,2,0
+2020-03-29,Montague,Texas,48337,1,0
+2020-03-29,Montgomery,Texas,48339,64,0
+2020-03-29,Morris,Texas,48343,1,0
+2020-03-29,Nacogdoches,Texas,48347,2,0
+2020-03-29,Navarro,Texas,48349,1,0
+2020-03-29,Nueces,Texas,48355,21,0
+2020-03-29,Oldham,Texas,48359,2,1
+2020-03-29,Orange,Texas,48361,1,0
+2020-03-29,Parker,Texas,48367,4,0
+2020-03-29,Polk,Texas,48373,1,0
+2020-03-29,Potter,Texas,48375,4,0
+2020-03-29,Randall,Texas,48381,3,0
+2020-03-29,Robertson,Texas,48395,2,0
+2020-03-29,Rockwall,Texas,48397,4,0
+2020-03-29,Rusk,Texas,48401,3,0
+2020-03-29,San Jacinto,Texas,48407,1,0
+2020-03-29,San Patricio,Texas,48409,1,0
+2020-03-29,Shelby,Texas,48419,1,0
+2020-03-29,Smith,Texas,48423,31,1
+2020-03-29,Starr,Texas,48427,2,0
+2020-03-29,Swisher,Texas,48437,1,0
+2020-03-29,Tarrant,Texas,48439,139,1
+2020-03-29,Taylor,Texas,48441,7,0
+2020-03-29,Terry,Texas,48445,3,0
+2020-03-29,Tom Green,Texas,48451,3,0
+2020-03-29,Travis,Texas,48453,179,1
+2020-03-29,Upshur,Texas,48459,1,0
+2020-03-29,Uvalde,Texas,48463,2,0
+2020-03-29,Val Verde,Texas,48465,5,0
+2020-03-29,Van Zandt,Texas,48467,1,1
+2020-03-29,Victoria,Texas,48469,3,0
+2020-03-29,Walker,Texas,48471,3,0
+2020-03-29,Waller,Texas,48473,3,0
+2020-03-29,Washington,Texas,48477,5,0
+2020-03-29,Webb,Texas,48479,30,0
+2020-03-29,Wharton,Texas,48481,6,0
+2020-03-29,Wichita,Texas,48485,28,0
+2020-03-29,Willacy,Texas,48489,2,0
+2020-03-29,Williamson,Texas,48491,37,1
+2020-03-29,Wilson,Texas,48493,2,0
+2020-03-29,Yoakum,Texas,48501,1,0
+2020-03-29,Young,Texas,48503,1,0
+2020-03-29,Box Elder,Utah,49003,4,0
+2020-03-29,Cache,Utah,49005,5,0
+2020-03-29,Davis,Utah,49011,69,1
+2020-03-29,Garfield,Utah,49017,1,0
+2020-03-29,Iron,Utah,49021,4,0
+2020-03-29,Morgan,Utah,49029,2,0
+2020-03-29,Salt Lake,Utah,49035,324,0
+2020-03-29,San Juan,Utah,49037,4,0
+2020-03-29,Summit,Utah,49043,159,0
+2020-03-29,Tooele,Utah,49045,9,0
+2020-03-29,Uintah,Utah,49047,1,0
+2020-03-29,Unknown,Utah,,1,1
+2020-03-29,Utah,Utah,49049,51,0
+2020-03-29,Wasatch,Utah,49051,40,0
+2020-03-29,Washington,Utah,49053,8,0
+2020-03-29,Weber,Utah,49057,37,0
+2020-03-29,Addison,Vermont,50001,17,0
+2020-03-29,Bennington,Vermont,50003,16,0
+2020-03-29,Caledonia,Vermont,50005,2,0
+2020-03-29,Chittenden,Vermont,50007,117,6
+2020-03-29,Franklin,Vermont,50011,9,0
+2020-03-29,Lamoille,Vermont,50015,12,0
+2020-03-29,Orange,Vermont,50017,3,0
+2020-03-29,Orleans,Vermont,50019,5,0
+2020-03-29,Rutland,Vermont,50021,6,0
+2020-03-29,Unknown,Vermont,,23,5
+2020-03-29,Washington,Vermont,50023,12,0
+2020-03-29,Windham,Vermont,50025,11,0
+2020-03-29,Windsor,Vermont,50027,18,1
+2020-03-29,Unknown,Virgin Islands,,23,0
+2020-03-29,Accomack,Virginia,51001,3,0
+2020-03-29,Albemarle,Virginia,51003,17,0
+2020-03-29,Alexandria city,Virginia,51510,25,0
+2020-03-29,Alleghany,Virginia,51005,1,0
+2020-03-29,Amelia,Virginia,51007,1,0
+2020-03-29,Amherst,Virginia,51009,2,0
+2020-03-29,Arlington,Virginia,51013,84,2
+2020-03-29,Bedford,Virginia,51019,2,0
+2020-03-29,Botetourt,Virginia,51023,2,0
+2020-03-29,Bristol city,Virginia,51520,1,0
+2020-03-29,Charles City,Virginia,51036,1,0
+2020-03-29,Charlottesville city,Virginia,51540,12,0
+2020-03-29,Chesapeake city,Virginia,51550,15,0
+2020-03-29,Chesterfield,Virginia,51041,13,0
+2020-03-29,Culpeper,Virginia,51047,2,0
+2020-03-29,Danville city,Virginia,51590,4,0
+2020-03-29,Fairfax,Virginia,51059,187,1
+2020-03-29,Fairfax city,Virginia,51600,1,0
+2020-03-29,Fauquier,Virginia,51061,6,0
+2020-03-29,Fluvanna,Virginia,51065,3,0
+2020-03-29,Franklin,Virginia,51067,5,0
+2020-03-29,Frederick,Virginia,51069,8,0
+2020-03-29,Fredericksburg city,Virginia,51630,1,0
+2020-03-29,Galax city,Virginia,51640,1,0
+2020-03-29,Gloucester,Virginia,51073,6,0
+2020-03-29,Goochland,Virginia,51075,6,0
+2020-03-29,Greene,Virginia,51079,1,0
+2020-03-29,Greensville,Virginia,51081,1,0
+2020-03-29,Halifax,Virginia,51083,1,0
+2020-03-29,Hampton city,Virginia,51650,7,0
+2020-03-29,Hanover,Virginia,51085,4,0
+2020-03-29,Harrisonburg city,Virginia,51660,5,0
+2020-03-29,Henrico,Virginia,51087,40,3
+2020-03-29,Hopewell city,Virginia,51670,1,0
+2020-03-29,Isle of Wight,Virginia,51093,3,0
+2020-03-29,James City,Virginia,51095,70,3
+2020-03-29,King George,Virginia,51099,2,0
+2020-03-29,Lancaster,Virginia,51103,1,0
+2020-03-29,Lee,Virginia,51105,2,0
+2020-03-29,Loudoun,Virginia,51107,61,0
+2020-03-29,Louisa,Virginia,51109,7,0
+2020-03-29,Lynchburg city,Virginia,51680,3,0
+2020-03-29,Madison,Virginia,51113,3,0
+2020-03-29,Manassas Park city,Virginia,51685,1,0
+2020-03-29,Manassas city,Virginia,51683,5,0
+2020-03-29,Mathews,Virginia,51115,2,0
+2020-03-29,Mecklenburg,Virginia,51117,4,0
+2020-03-29,Montgomery,Virginia,51121,1,0
+2020-03-29,Nelson,Virginia,51125,2,0
+2020-03-29,New Kent,Virginia,51127,1,0
+2020-03-29,Newport News city,Virginia,51700,17,1
+2020-03-29,Norfolk city,Virginia,51710,14,0
+2020-03-29,Northampton,Virginia,51131,1,0
+2020-03-29,Northumberland,Virginia,51133,2,0
+2020-03-29,Nottoway,Virginia,51135,1,0
+2020-03-29,Orange,Virginia,51137,1,0
+2020-03-29,Pittsylvania,Virginia,51143,1,0
+2020-03-29,Poquoson city,Virginia,51735,2,0
+2020-03-29,Portsmouth city,Virginia,51740,4,0
+2020-03-29,Powhatan,Virginia,51145,1,0
+2020-03-29,Prince Edward,Virginia,51147,2,0
+2020-03-29,Prince George,Virginia,51149,4,0
+2020-03-29,Prince William,Virginia,51153,72,0
+2020-03-29,Radford city,Virginia,51750,1,0
+2020-03-29,Richmond city,Virginia,51760,25,0
+2020-03-29,Roanoke,Virginia,51161,2,0
+2020-03-29,Roanoke city,Virginia,51770,1,0
+2020-03-29,Rockbridge,Virginia,51163,2,0
+2020-03-29,Rockingham,Virginia,51165,4,0
+2020-03-29,Shenandoah,Virginia,51171,4,0
+2020-03-29,Southampton,Virginia,51175,1,0
+2020-03-29,Spotsylvania,Virginia,51177,5,0
+2020-03-29,Stafford,Virginia,51179,13,0
+2020-03-29,Suffolk city,Virginia,51800,1,0
+2020-03-29,Tazewell,Virginia,51185,1,0
+2020-03-29,Virginia Beach city,Virginia,51810,49,0
+2020-03-29,Warren,Virginia,51187,2,0
+2020-03-29,Washington,Virginia,51191,2,0
+2020-03-29,Williamsburg city,Virginia,51830,7,1
+2020-03-29,Winchester city,Virginia,51840,1,0
+2020-03-29,Wythe,Virginia,51197,1,0
+2020-03-29,York,Virginia,51199,9,0
+2020-03-29,Adams,Washington,53001,7,0
+2020-03-29,Benton,Washington,53005,101,5
+2020-03-29,Chelan,Washington,53007,15,2
+2020-03-29,Clallam,Washington,53009,6,0
+2020-03-29,Clark,Washington,53011,90,6
+2020-03-29,Columbia,Washington,53013,1,0
+2020-03-29,Cowlitz,Washington,53015,13,0
+2020-03-29,Douglas,Washington,53017,5,0
+2020-03-29,Ferry,Washington,53019,1,0
+2020-03-29,Franklin,Washington,53021,32,0
+2020-03-29,Grant,Washington,53025,58,1
+2020-03-29,Grays Harbor,Washington,53027,1,0
+2020-03-29,Island,Washington,53029,95,1
+2020-03-29,Jefferson,Washington,53031,14,0
+2020-03-29,King,Washington,53033,2163,146
+2020-03-29,Kitsap,Washington,53035,56,1
+2020-03-29,Kittitas,Washington,53037,8,0
+2020-03-29,Klickitat,Washington,53039,7,1
+2020-03-29,Lewis,Washington,53041,10,0
+2020-03-29,Lincoln,Washington,53043,1,0
+2020-03-29,Mason,Washington,53045,2,0
+2020-03-29,Okanogan,Washington,53047,3,0
+2020-03-29,Pierce,Washington,53053,317,6
+2020-03-29,San Juan,Washington,53055,4,0
+2020-03-29,Skagit,Washington,53057,101,3
+2020-03-29,Skamania,Washington,53059,1,0
+2020-03-29,Snohomish,Washington,53061,1067,23
+2020-03-29,Spokane,Washington,53063,140,4
+2020-03-29,Stevens,Washington,53065,3,0
+2020-03-29,Thurston,Washington,53067,36,0
+2020-03-29,Walla Walla,Washington,53071,7,0
+2020-03-29,Whatcom,Washington,53073,116,7
+2020-03-29,Whitman,Washington,53075,6,0
+2020-03-29,Yakima,Washington,53077,147,3
+2020-03-29,Berkeley,West Virginia,54003,10,0
+2020-03-29,Cabell,West Virginia,54011,1,0
+2020-03-29,Greenbrier,West Virginia,54025,2,0
+2020-03-29,Hancock,West Virginia,54029,3,0
+2020-03-29,Harrison,West Virginia,54033,7,0
+2020-03-29,Jackson,West Virginia,54035,8,0
+2020-03-29,Jefferson,West Virginia,54037,5,0
+2020-03-29,Kanawha,West Virginia,54039,19,0
+2020-03-29,Logan,West Virginia,54045,1,0
+2020-03-29,Marion,West Virginia,54049,5,1
+2020-03-29,Marshall,West Virginia,54051,4,0
+2020-03-29,Mason,West Virginia,54053,3,0
+2020-03-29,Mercer,West Virginia,54055,2,0
+2020-03-29,Monongalia,West Virginia,54061,30,0
+2020-03-29,Morgan,West Virginia,54065,1,0
+2020-03-29,Ohio,West Virginia,54069,7,0
+2020-03-29,Pleasants,West Virginia,54073,1,0
+2020-03-29,Preston,West Virginia,54077,1,0
+2020-03-29,Putnam,West Virginia,54079,3,0
+2020-03-29,Raleigh,West Virginia,54081,4,0
+2020-03-29,Tucker,West Virginia,54093,2,0
+2020-03-29,Upshur,West Virginia,54097,1,0
+2020-03-29,Wetzel,West Virginia,54103,1,0
+2020-03-29,Wirt,West Virginia,54105,1,0
+2020-03-29,Wood,West Virginia,54107,2,0
+2020-03-29,Bayfield,Wisconsin,55007,2,0
+2020-03-29,Brown,Wisconsin,55009,6,0
+2020-03-29,Calumet,Wisconsin,55015,1,0
+2020-03-29,Chippewa,Wisconsin,55017,4,0
+2020-03-29,Clark,Wisconsin,55019,3,0
+2020-03-29,Columbia,Wisconsin,55021,9,0
+2020-03-29,Dane,Wisconsin,55025,179,1
+2020-03-29,Dodge,Wisconsin,55027,8,0
+2020-03-29,Douglas,Wisconsin,55031,6,0
+2020-03-29,Dunn,Wisconsin,55033,3,0
+2020-03-29,Eau Claire,Wisconsin,55035,10,0
+2020-03-29,Fond du Lac,Wisconsin,55039,20,1
+2020-03-29,Grant,Wisconsin,55043,1,0
+2020-03-29,Green,Wisconsin,55045,4,0
+2020-03-29,Iowa,Wisconsin,55049,3,0
+2020-03-29,Iron,Wisconsin,55051,1,1
+2020-03-29,Jefferson,Wisconsin,55055,8,0
+2020-03-29,Juneau,Wisconsin,55057,3,0
+2020-03-29,Kenosha,Wisconsin,55059,30,0
+2020-03-29,La Crosse,Wisconsin,55063,15,0
+2020-03-29,Marathon,Wisconsin,55073,1,0
+2020-03-29,Marinette,Wisconsin,55075,1,0
+2020-03-29,Milwaukee,Wisconsin,55079,565,9
+2020-03-29,Monroe,Wisconsin,55081,1,0
+2020-03-29,Oneida,Wisconsin,55085,1,0
+2020-03-29,Outagamie,Wisconsin,55087,6,0
+2020-03-29,Ozaukee,Wisconsin,55089,34,3
+2020-03-29,Pierce,Wisconsin,55093,4,0
+2020-03-29,Portage,Wisconsin,55097,1,0
+2020-03-29,Racine,Wisconsin,55101,17,0
+2020-03-29,Richland,Wisconsin,55103,2,0
+2020-03-29,Rock,Wisconsin,55105,14,0
+2020-03-29,Sauk,Wisconsin,55111,12,1
+2020-03-29,Sheboygan,Wisconsin,55117,8,0
+2020-03-29,St. Croix,Wisconsin,55109,4,0
+2020-03-29,Vilas,Wisconsin,55125,2,0
+2020-03-29,Walworth,Wisconsin,55127,6,0
+2020-03-29,Washington,Wisconsin,55131,31,0
+2020-03-29,Waukesha,Wisconsin,55133,83,0
+2020-03-29,Waupaca,Wisconsin,55135,1,1
+2020-03-29,Winnebago,Wisconsin,55139,8,0
+2020-03-29,Wood,Wisconsin,55141,2,0
+2020-03-29,Albany,Wyoming,56001,1,0
+2020-03-29,Campbell,Wyoming,56005,1,0
+2020-03-29,Carbon,Wyoming,56007,3,0
+2020-03-29,Converse,Wyoming,56009,1,0
+2020-03-29,Fremont,Wyoming,56013,23,0
+2020-03-29,Goshen,Wyoming,56015,1,0
+2020-03-29,Hot Springs,Wyoming,56017,1,0
+2020-03-29,Johnson,Wyoming,56019,5,0
+2020-03-29,Laramie,Wyoming,56021,19,0
+2020-03-29,Natrona,Wyoming,56025,9,0
+2020-03-29,Park,Wyoming,56029,1,0
+2020-03-29,Sheridan,Wyoming,56033,6,0
+2020-03-29,Sublette,Wyoming,56035,1,0
+2020-03-29,Sweetwater,Wyoming,56037,1,0
+2020-03-29,Teton,Wyoming,56039,14,0
+2020-03-29,Washakie,Wyoming,56043,1,0

--- a/us-states.csv
+++ b/us-states.csv
@@ -1277,7 +1277,7 @@ date,state,fips,cases,deaths
 2020-03-25,Virgin Islands,78,17,0
 2020-03-25,Virginia,51,391,9
 2020-03-25,Washington,53,2585,130
-2020-03-25,West Virginia,54,52,0
+2020-03-25,West Virginia,54,51,0
 2020-03-25,Wisconsin,55,623,7
 2020-03-25,Wyoming,56,49,0
 2020-03-26,Alabama,01,538,3
@@ -1345,6 +1345,7 @@ date,state,fips,cases,deaths
 2020-03-27,District of Columbia,11,304,4
 2020-03-27,Florida,12,3198,46
 2020-03-27,Georgia,13,2198,64
+2020-03-27,Guam,66,53,1
 2020-03-27,Hawaii,15,120,0
 2020-03-27,Idaho,16,231,4
 2020-03-27,Illinois,17,3029,37
@@ -1373,6 +1374,7 @@ date,state,fips,cases,deaths
 2020-03-27,Oklahoma,40,322,8
 2020-03-27,Oregon,41,414,12
 2020-03-27,Pennsylvania,42,2218,23
+2020-03-27,Puerto Rico,72,79,3
 2020-03-27,Rhode Island,44,203,0
 2020-03-27,South Carolina,45,539,13
 2020-03-27,South Dakota,46,58,1
@@ -1380,6 +1382,7 @@ date,state,fips,cases,deaths
 2020-03-27,Texas,48,1942,23
 2020-03-27,Utah,49,480,2
 2020-03-27,Vermont,50,184,10
+2020-03-27,Virgin Islands,78,19,0
 2020-03-27,Virginia,51,606,14
 2020-03-27,Washington,53,3770,177
 2020-03-27,West Virginia,54,96,0
@@ -1396,6 +1399,7 @@ date,state,fips,cases,deaths
 2020-03-28,District of Columbia,11,342,4
 2020-03-28,Florida,12,4038,56
 2020-03-28,Georgia,13,2447,79
+2020-03-28,Guam,66,57,1
 2020-03-28,Hawaii,15,151,0
 2020-03-28,Idaho,16,261,5
 2020-03-28,Illinois,17,3547,50
@@ -1420,10 +1424,12 @@ date,state,fips,cases,deaths
 2020-03-28,New York,36,53363,782
 2020-03-28,North Carolina,37,972,4
 2020-03-28,North Dakota,38,94,1
+2020-03-28,Northern Mariana Islands,69,2,0
 2020-03-28,Ohio,39,1406,25
 2020-03-28,Oklahoma,40,377,15
 2020-03-28,Oregon,41,479,13
 2020-03-28,Pennsylvania,42,2815,35
+2020-03-28,Puerto Rico,72,100,3
 2020-03-28,Rhode Island,44,239,2
 2020-03-28,South Carolina,45,660,15
 2020-03-28,South Dakota,46,68,1
@@ -1431,8 +1437,64 @@ date,state,fips,cases,deaths
 2020-03-28,Texas,48,2161,29
 2020-03-28,Utah,49,608,2
 2020-03-28,Vermont,50,211,12
+2020-03-28,Virgin Islands,78,19,0
 2020-03-28,Virginia,51,740,17
 2020-03-28,Washington,53,4311,191
 2020-03-28,West Virginia,54,113,0
 2020-03-28,Wisconsin,55,1042,17
 2020-03-28,Wyoming,56,84,0
+2020-03-29,Alabama,01,830,5
+2020-03-29,Alaska,02,114,1
+2020-03-29,Arizona,04,929,18
+2020-03-29,Arkansas,05,449,6
+2020-03-29,California,06,6266,130
+2020-03-29,Colorado,08,2315,47
+2020-03-29,Connecticut,09,1993,34
+2020-03-29,Delaware,10,232,6
+2020-03-29,District of Columbia,11,342,4
+2020-03-29,Florida,12,4942,59
+2020-03-29,Georgia,13,2683,83
+2020-03-29,Guam,66,58,1
+2020-03-29,Hawaii,15,175,0
+2020-03-29,Idaho,16,310,6
+2020-03-29,Illinois,17,4613,70
+2020-03-29,Indiana,18,1514,32
+2020-03-29,Iowa,19,336,4
+2020-03-29,Kansas,20,332,7
+2020-03-29,Kentucky,21,439,9
+2020-03-29,Louisiana,22,3540,152
+2020-03-29,Maine,23,253,3
+2020-03-29,Maryland,24,1244,11
+2020-03-29,Massachusetts,25,4955,48
+2020-03-29,Michigan,26,5486,132
+2020-03-29,Minnesota,27,504,9
+2020-03-29,Mississippi,28,759,14
+2020-03-29,Missouri,29,903,12
+2020-03-29,Montana,30,161,1
+2020-03-29,Nebraska,31,137,2
+2020-03-29,Nevada,32,920,15
+2020-03-29,New Hampshire,33,258,3
+2020-03-29,New Jersey,34,13386,161
+2020-03-29,New Mexico,35,237,2
+2020-03-29,New York,36,59568,965
+2020-03-29,North Carolina,37,1167,6
+2020-03-29,North Dakota,38,98,1
+2020-03-29,Northern Mariana Islands,69,2,0
+2020-03-29,Ohio,39,1665,30
+2020-03-29,Oklahoma,40,429,16
+2020-03-29,Oregon,41,548,13
+2020-03-29,Pennsylvania,42,3441,40
+2020-03-29,Puerto Rico,72,127,5
+2020-03-29,Rhode Island,44,294,3
+2020-03-29,South Carolina,45,774,16
+2020-03-29,South Dakota,46,90,1
+2020-03-29,Tennessee,47,1537,7
+2020-03-29,Texas,48,2712,35
+2020-03-29,Utah,49,719,2
+2020-03-29,Vermont,50,235,12
+2020-03-29,Virgin Islands,78,23,0
+2020-03-29,Virginia,51,890,22
+2020-03-29,Washington,53,4896,207
+2020-03-29,West Virginia,54,124,1
+2020-03-29,Wisconsin,55,1120,17
+2020-03-29,Wyoming,56,87,0


### PR DESCRIPTION
Adds missing rows for Guam, PR, VI for 3/27 and 3/28.
Corrects cases data for Harris County, Texas for 3/28.
Corrects deaths data for Volusia, Florida for 3/28.
Removes one case from Hancock, WV and WV state for 3/25 that was reassigned.